### PR TITLE
Layer 4 supply-chain trust signals: CodeQL, Scorecard, Dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,29 @@
+version: 2
+updates:
+  # Go module dependencies.
+  - package-ecosystem: gomod
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "deps"
+    groups:
+      go-deps:
+        patterns:
+          - "*"
+
+  # Versions of the actions pinned in our workflows.
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+name: codeql
+
+# Static analysis for the Go code (cmd/, internal/) via GitHub CodeQL.
+# build-mode: none analyzes the source directly, so this does not need the
+# C/libbpf validator toolchain. Results surface under Security > Code scanning.
+#
+# Security note: no untrusted ${{ github.event.* }} value is interpolated into
+# any run: shell here, so workflow-injection via PR titles/branches does not
+# apply to this file.
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "27 4 * * 1"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (Go)
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      contents: read
+      security-events: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: go
+          build-mode: none
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:go"

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -1,0 +1,57 @@
+name: scorecard
+
+# OpenSSF Scorecard supply-chain risk assessment. Publishes results to the
+# public Scorecard API (so the README badge resolves) and uploads SARIF to
+# GitHub code scanning.
+#
+# Security note: no untrusted ${{ github.event.* }} value is interpolated into
+# any run: shell here, so workflow-injection does not apply to this file.
+
+on:
+  branch_protection_rule:
+  schedule:
+    - cron: "41 5 * * 1"
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analysis:
+    name: Scorecard analysis
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    permissions:
+      security-events: write   # upload SARIF to code scanning
+      id-token: write          # publish results to the Scorecard API
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Run analysis
+        uses: ossf/scorecard-action@v2
+        with:
+          results_file: results.sarif
+          results_format: sarif
+          publish_results: true
+
+      - name: Upload artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: scorecard-results
+          path: results.sarif
+          retention-days: 5
+
+      - name: Upload to code scanning
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: results.sarif

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once a
 ## [Unreleased]
 
 ### Added
+- Supply-chain trust signals: GitHub CodeQL static analysis
+  (`.github/workflows/codeql.yml`), OpenSSF Scorecard
+  (`.github/workflows/scorecard.yml`), and Dependabot
+  (`.github/dependabot.yml`, Go modules + pinned actions). README gains CI,
+  CodeQL, Scorecard, and license badges; `docs/supply-chain.md` documents the
+  controls and the maintainer-side repo settings (branch protection, secret
+  scanning, OpenSSF Best Practices registration). SBOM + cosign keyless signing
+  already shipped in `release-artifacts.yml`.
 - Zero-infrastructure CI on-ramp: `.github/workflows/bpfcompat-example-hosted.yml`
   runs the full QEMU VM compatibility gate on a stock GitHub-hosted
   `ubuntu-latest` runner. GitHub-hosted Linux runners now expose `/dev/kvm`, so

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # bpfcompat
 
+[![CI](https://github.com/Kernel-Guard/bpfcompat/actions/workflows/ci.yml/badge.svg)](https://github.com/Kernel-Guard/bpfcompat/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/Kernel-Guard/bpfcompat/actions/workflows/codeql.yml/badge.svg)](https://github.com/Kernel-Guard/bpfcompat/actions/workflows/codeql.yml)
+[![OpenSSF Scorecard](https://api.scorecard.dev/projects/github.com/Kernel-Guard/bpfcompat/badge)](https://scorecard.dev/viewer/?uri=github.com/Kernel-Guard/bpfcompat)
+[![License: Apache-2.0](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](LICENSE)
+
 `bpfcompat` is an open-source compatibility validator for compiled eBPF
 artifacts. It runs real libbpf load/attach checks against Linux kernel profiles
 and produces JSON/Markdown reports that can fail CI when an artifact regresses.
@@ -402,6 +407,7 @@ planning notes — useful for contributors, not needed to use the tool):
 
 - [`docs/acceptance-tests.md`](docs/acceptance-tests.md)
 - [`docs/falco-parity.md`](docs/falco-parity.md)
+- [`docs/supply-chain.md`](docs/supply-chain.md) — supply-chain controls and maintainer repo settings
 - [`docs/backend-execution-proof.md`](docs/backend-execution-proof.md)
 - [`docs/external-ci-proof.md`](docs/external-ci-proof.md)
 - remaining `docs/*.md` proof, runbook, and checklist documents
@@ -430,6 +436,30 @@ Operator guidance:
 - require write auth or explicit anonymous-demo flags for POST paths;
 - do not enable internal-host or `file://` fetches outside controlled tests;
 - run host-loading flows only through a local policy-gated agent path.
+
+### Supply-chain posture
+
+- **Static analysis:** GitHub CodeQL (`codeql.yml`) plus `govulncheck` and
+  `golangci-lint` in CI on every PR.
+- **Dependency updates:** Dependabot (`dependabot.yml`) for Go modules and
+  pinned GitHub Actions, grouped weekly.
+- **Risk scoring:** OpenSSF Scorecard (`scorecard.yml`), published to the
+  public Scorecard API (badge above).
+- **Signed releases:** tag builds produce a CycloneDX SBOM and cosign keyless
+  (Sigstore OIDC) signatures over the binaries, `SHA256SUMS`, and SBOM
+  (`release-artifacts.yml`). Verify with:
+
+  ```bash
+  cosign verify-blob \
+    --certificate SHA256SUMS.crt --signature SHA256SUMS.sig \
+    --certificate-identity-regexp 'https://github.com/Kernel-Guard/bpfcompat/.*' \
+    --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+    SHA256SUMS
+  ```
+
+Maintainer-side repo settings (branch protection, secret-scanning push
+protection, OpenSSF Best Practices registration) are tracked in
+[`docs/supply-chain.md`](docs/supply-chain.md).
 
 ## License
 

--- a/docs/supply-chain.md
+++ b/docs/supply-chain.md
@@ -1,0 +1,61 @@
+# Supply-Chain & Trust Posture
+
+This document records the supply-chain controls that ship as code in this
+repository and the maintainer-side settings that must be configured in the
+GitHub repository UI/API (they cannot be set from committed files).
+
+## In-repo controls (automated)
+
+| Control | Where | Trigger |
+|---|---|---|
+| CodeQL static analysis (Go, security-and-quality) | `.github/workflows/codeql.yml` | push/PR to `main`, weekly, manual |
+| OpenSSF Scorecard | `.github/workflows/scorecard.yml` | push to `main`, weekly, `branch_protection_rule`, manual |
+| Dependency updates (gomod + github-actions) | `.github/dependabot.yml` | weekly (Mondays) |
+| Vulnerability scan | `govulncheck` in `.github/workflows/ci.yml` | every PR |
+| Lint | `golangci-lint` in `.github/workflows/ci.yml` | every PR |
+| SBOM (CycloneDX) | `.github/workflows/release-artifacts.yml` | push to `main`, tags, manual |
+| Keyless signing (cosign / Sigstore OIDC) | `.github/workflows/release-artifacts.yml` | tag releases (`v*`) |
+| SHA256 checksums | `.github/workflows/release-artifacts.yml` | all builds |
+
+### Verifying a signed release
+
+```bash
+cosign verify-blob \
+  --certificate SHA256SUMS.crt --signature SHA256SUMS.sig \
+  --certificate-identity-regexp 'https://github.com/Kernel-Guard/bpfcompat/.*' \
+  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  SHA256SUMS
+sha256sum -c SHA256SUMS
+```
+
+## Maintainer-side settings (configure once, in the GitHub UI/API)
+
+These are not files in the repo. Track their status here.
+
+- [ ] **Branch protection on `main`**: require PRs, require status checks
+      (`ci`, `codeql`), require up-to-date branches, restrict force-pushes.
+      Settings → Branches → Add rule, or:
+      `gh api -X PUT repos/Kernel-Guard/bpfcompat/branches/main/protection ...`
+- [ ] **Secret scanning + push protection**: Settings → Code security → enable
+      "Secret scanning" and "Push protection".
+- [ ] **Dependabot alerts + security updates**: Settings → Code security →
+      enable "Dependabot alerts" and "Dependabot security updates".
+- [ ] **Code scanning default setup OFF if CodeQL workflow is used** (avoid
+      double analysis): Settings → Code security → Code scanning.
+- [ ] **OpenSSF Best Practices badge**: register the project at
+      <https://www.bestpractices.dev/>, then add the returned badge:
+      `[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/<ID>/badge)](https://www.bestpractices.dev/projects/<ID>)`
+      to the README badge row. (Scorecard is automated; this one needs a
+      one-time self-assessment.)
+- [ ] **Scorecard badge publishing**: the first successful `scorecard.yml` run
+      on `main` populates <https://scorecard.dev/viewer/?uri=github.com/Kernel-Guard/bpfcompat>
+      and resolves the README badge.
+
+## Notes
+
+- `publish_results: true` in the Scorecard workflow requires the repository to
+  be public; it is a no-op signal otherwise.
+- CodeQL uses `build-mode: none`, so it does not need the C/libbpf validator
+  toolchain (the validator is a separate non-Go component).
+- The `Kernel-Guard` GitHub org and the "KernelGuard" site branding should be
+  reconciled before a wider public launch; see the project roadmap.

--- a/docs/supply-chain.md
+++ b/docs/supply-chain.md
@@ -32,16 +32,21 @@ sha256sum -c SHA256SUMS
 
 These are not files in the repo. Track their status here.
 
-- [ ] **Branch protection on `main`**: require PRs, require status checks
-      (`ci`, `codeql`), require up-to-date branches, restrict force-pushes.
-      Settings → Branches → Add rule, or:
-      `gh api -X PUT repos/Kernel-Guard/bpfcompat/branches/main/protection ...`
-- [ ] **Secret scanning + push protection**: Settings → Code security → enable
-      "Secret scanning" and "Push protection".
-- [ ] **Dependabot alerts + security updates**: Settings → Code security →
-      enable "Dependabot alerts" and "Dependabot security updates".
+- [x] **Branch protection on `main`** (wired 2026-06-14): blocks force-pushes
+      and deletions, requires conversation resolution, and requires the CI
+      checks `Test (-race)`, `golangci-lint`, `govulncheck`, `Build (Go side)`.
+      `enforce_admins` is off (solo-maintainer bypass) and no review count is
+      required. Add `Analyze (Go)` to the required contexts once `codeql.yml`
+      is on `main`. Set via:
+      `gh api -X PUT repos/Kernel-Guard/bpfcompat/branches/main/protection --input -`
+- [x] **Secret scanning + push protection** (wired 2026-06-14): enabled via
+      `gh api -X PATCH repos/Kernel-Guard/bpfcompat` with
+      `security_and_analysis.secret_scanning` + `secret_scanning_push_protection`.
+- [x] **Dependabot alerts + security updates** (wired 2026-06-14): enabled via
+      `gh api -X PUT .../vulnerability-alerts` and `.../automated-security-fixes`.
 - [ ] **Code scanning default setup OFF if CodeQL workflow is used** (avoid
-      double analysis): Settings → Code security → Code scanning.
+      double analysis): Settings → Code security → Code scanning. Do this after
+      `codeql.yml` lands on `main`.
 - [ ] **OpenSSF Best Practices badge**: register the project at
       <https://www.bestpractices.dev/>, then add the returned badge:
       `[![OpenSSF Best Practices](https://www.bestpractices.dev/projects/<ID>/badge)](https://www.bestpractices.dev/projects/<ID>)`


### PR DESCRIPTION
## Why

Cheap, high-credibility trust signals for getting eBPF projects to adopt bpfcompat in their CI. SBOM + cosign keyless signing already shipped in `release-artifacts.yml`; this adds the missing pieces.

> Stacked on #1 (`hosted-runner-onramp`). Merge #1 first, then this — or retarget this to `main` after #1 lands.

## What

- **`.github/workflows/codeql.yml`** — CodeQL Go static analysis, `build-mode: none` (no C/libbpf toolchain needed), `security-and-quality` queries; push/PR/weekly.
- **`.github/workflows/scorecard.yml`** — OpenSSF Scorecard, publishes to the public Scorecard API + SARIF to code scanning.
- **`.github/dependabot.yml`** — weekly grouped updates for Go modules and pinned GitHub Actions.
- **README** — CI / CodeQL / Scorecard / license badges + a Supply-chain posture section with a `cosign verify-blob` example.
- **`docs/supply-chain.md`** — in-repo controls table + checklist of maintainer-side settings that can't be set from files (branch protection, secret-scanning push protection, OpenSSF Best Practices registration).

## Notes

- No untrusted `github.event.*` input is interpolated into any `run:` step in the new workflows.
- The Scorecard badge stays "unknown" until the first `scorecard.yml` run on `main` succeeds.
- After enabling the CodeQL workflow, turn OFF Code Scanning "default setup" to avoid double analysis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)