### PR TITLE
Fix security workflows: CodeQL autobuild + pin scorecard-action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -36,11 +36,20 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: "1.25.11"
+          cache: true
+
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3
         with:
           languages: go
-          build-mode: none
+          # Go does not support build-mode: none; autobuild runs `go build`,
+          # which needs no C/libbpf toolchain (the validator is a separate
+          # non-Go component).
+          build-mode: autobuild
           queries: security-and-quality
 
       - name: Perform CodeQL Analysis

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -30,6 +30,7 @@ jobs:
     permissions:
       security-events: write   # upload SARIF to code scanning
       id-token: write          # publish results to the Scorecard API
+      actions: read            # evaluate workflow token-permission/pinning checks
       contents: read
     steps:
       - name: Checkout
@@ -38,7 +39,7 @@ jobs:
           persist-credentials: false
 
       - name: Run analysis
-        uses: ossf/scorecard-action@v2
+        uses: ossf/scorecard-action@v2.4.3
         with:
           results_file: results.sarif
           results_format: sarif

--- a/docs/supply-chain.md
+++ b/docs/supply-chain.md
@@ -60,7 +60,8 @@ These are not files in the repo. Track their status here.
 
 - `publish_results: true` in the Scorecard workflow requires the repository to
   be public; it is a no-op signal otherwise.
-- CodeQL uses `build-mode: none`, so it does not need the C/libbpf validator
-  toolchain (the validator is a separate non-Go component).
+- CodeQL uses `build-mode: autobuild` (Go does not support `none`); autobuild
+  runs `go build`, which does not need the C/libbpf validator toolchain (the
+  validator is a separate non-Go component).
 - The `Kernel-Guard` GitHub org and the "KernelGuard" site branding should be
   reconciled before a wider public launch; see the project roadmap.


### PR DESCRIPTION
First on-`main` runs of the Layer 4 workflows failed for two fixable reasons:

- **CodeQL**: `Go does not support the none build mode`. Switched to `build-mode: autobuild` (runs `go build`, no C/libbpf toolchain needed) and pinned Go 1.25.11 to match CI.
- **Scorecard**: `ossf/scorecard-action@v2` no longer resolves. Pinned to `v2.4.3` and added `actions: read` so the token-permission/pinning checks evaluate instead of degrading.

🤖 Generated with [Claude Code](https://claude.com/claude-code)