### PR TITLE
Wire SCORECARD_TOKEN for Branch-Protection check

### DIFF
--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -43,6 +43,9 @@ jobs:
         with:
           results_file: results.sarif
           results_format: sarif
+          # Fine-grained PAT (Administration: read) so Scorecard can read
+          # branch-protection rules, which the default GITHUB_TOKEN cannot.
+          repo_token: ${{ secrets.SCORECARD_TOKEN }}
           publish_results: true
 
       - name: Upload artifact


### PR DESCRIPTION
Passes the fine-grained PAT (Administration: read) via `repo_token` so Scorecard can read branch-protection rules — converts the Branch-Protection check from `-1` (internal error) to a real score.

🤖 Generated with [Claude Code](https://claude.com/claude-code)