### PR TITLE
Add live demo link (demo.kernelguard.net)

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,9 @@ The core question is simple:
 > Will this `.bpf.o` load and attach on the kernels I care about, and if not,
 > what failed?
 
+**Live demo:** [demo.kernelguard.net](https://demo.kernelguard.net) — upload a
+`.bpf.o` and see the compatibility matrix.
+
 ## Why not just rely on CO-RE / BTFHub?
 
 CO-RE makes a `.bpf.o` *portable in principle*; it does not guarantee it will


### PR DESCRIPTION
Surfaces the live demo at [demo.kernelguard.net](https://demo.kernelguard.net) near the top of the README, now that the Azure demo serves on a clean custom domain with a valid Let's Encrypt cert (replacing the auto-generated `*.cloudapp.azure.com` hostname).

🤖 Generated with [Claude Code](https://claude.com/claude-code)