### PR TITLE
Guard validate UI against submitting with no artifact

### DIFF
--- a/internal/api/ui.go
+++ b/internal/api/ui.go
@@ -2750,6 +2750,8 @@ programs:
         if (mode === "artifact") {
           if (byId("artifactFile").files[0]) {
             fd.append("artifact_file", byId("artifactFile").files[0]);
+          } else {
+            throw new Error("Choose a compiled BPF object (.bpf.o) to validate, or switch to the source tab.");
           }
         } else {
           if (byId("sourceFile").files[0]) {
@@ -2757,6 +2759,9 @@ programs:
           }
           if (byId("sourceCode").value.trim()) {
             fd.append("source_code", byId("sourceCode").value);
+          }
+          if (!byId("sourceFile").files[0] && !byId("sourceCode").value.trim()) {
+            throw new Error("Provide BPF source (upload a .c file or paste source code) before running.");
           }
           if (byId("clangFlags").value.trim()) {
             fd.append("clang_flags", byId("clangFlags").value.trim());


### PR DESCRIPTION
## What
The Validate panel sent the request even when no `.bpf.o` (artifact tab) or source (source tab) was provided, so the server rejected it with a raw `HTTP 400: provide artifact_file, source_file, or source_code`. Reported as "can't run validation on the live demo, 400 error".

## Fix
Client-side guard in `internal/api/ui.go` that blocks submit and shows a clear message before sending:
- artifact tab, no file → "Choose a compiled BPF object (.bpf.o) to validate, or switch to the source tab."
- source tab, no source → "Provide BPF source (upload a .c file or paste source code) before running."

## Testing
- `go test ./internal/api/` passes
- Verified the live backend itself is healthy: ran a real validation against bpfcompat.kernelguard.net end-to-end (202 → completed, exit_code 0)
- Built the binary, served locally, confirmed both guard strings render in the UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)