### PR TITLE
Document deploying the git-ignored aegis sample artifact

### DIFF
--- a/docs/hetzner-runbook.md
+++ b/docs/hetzner-runbook.md
@@ -35,6 +35,29 @@ export HETZNER_HOST=<server-ip>
 make hetzner-bootstrap-vm
 ```
 
+## 1b) Install the "Try our aegis sample" artifact
+
+The empty-state **"Try our aegis sample"** button serves
+`examples/aegis-live/aegis.bpf.o`. That object is **git-ignored** (we never
+commit built `.bpf.o`s), so a fresh checkout does not contain it and the
+`/api/v1/sample/aegis/artifact` endpoint 404s until you copy it out-of-band.
+
+Copy the sample to a path that survives re-provisioning (the state dir is not
+wiped by re-clones) and point the server at it via `BPFCOMPAT_SAMPLE_ARTIFACT`:
+
+```bash
+scp examples/aegis-live/aegis.bpf.o \
+  root@$HETZNER_HOST:/var/lib/bpfcompat-demo/sample-aegis.bpf.o
+ssh root@$HETZNER_HOST '
+  chown bpfcompat-demo:bpfcompat-demo /var/lib/bpfcompat-demo/sample-aegis.bpf.o
+  chmod 0644 /var/lib/bpfcompat-demo/sample-aegis.bpf.o
+  grep -q "^BPFCOMPAT_SAMPLE_ARTIFACT=" /etc/bpfcompat/serve.env \
+    && sed -i "s|^BPFCOMPAT_SAMPLE_ARTIFACT=.*|BPFCOMPAT_SAMPLE_ARTIFACT=/var/lib/bpfcompat-demo/sample-aegis.bpf.o|" /etc/bpfcompat/serve.env \
+    || echo "BPFCOMPAT_SAMPLE_ARTIFACT=/var/lib/bpfcompat-demo/sample-aegis.bpf.o" >> /etc/bpfcompat/serve.env'
+```
+
+(If the unit is already running, `systemctl restart bpfcompat-serve` after.)
+
 ## 2) Set the write key and start the demo server
 
 The server binds `127.0.0.1:8080` only. Anonymous visitors may validate and read

--- a/packaging/systemd/bpfcompat-serve.env.example
+++ b/packaging/systemd/bpfcompat-serve.env.example
@@ -21,6 +21,12 @@ BPFCOMPAT_API_REDACT_RUNTIME_DETAILS=true
 # Do not mirror demo runs into a cloud registry.
 BPFCOMPAT_API_AUTO_SYNC_REGISTRY=false
 
+# Path to the bundled "Try our aegis sample" artifact. The default
+# (examples/aegis-live/aegis.bpf.o, relative to WorkingDirectory) is git-ignored,
+# so on a fresh deployment copy the object out-of-band and point this at it (see
+# docs/hetzner-runbook.md step 1b). Leave unset to use the in-repo default.
+BPFCOMPAT_SAMPLE_ARTIFACT=/var/lib/bpfcompat-demo/sample-aegis.bpf.o
+
 # Note: the run tree location is set via the --workdir flag in the unit's
 # ExecStart (/var/lib/bpfcompat-demo), not an env var. .bpfcompat/runs/** under
 # it holds per-run SSH keys, so it must stay inside the state dir only.


### PR DESCRIPTION
## What
The empty-state **"Try our aegis sample"** button serves `examples/aegis-live/aegis.bpf.o` via `/api/v1/sample/aegis/artifact`. That object is git-ignored (we never commit built `.bpf.o`s), so a fresh server checkout doesn't have it and the endpoint 404s — the button fails with "sample unavailable".

Reported live on bpfcompat.kernelguard.net.

## Fix
- Live host fixed out-of-band: copied the sample to `/var/lib/bpfcompat-demo/sample-aegis.bpf.o` and set `BPFCOMPAT_SAMPLE_ARTIFACT` (verified: endpoint 200, aegis boundary spread runs — 5.4/5.15 fail, 6.1/6.8 pass, exit 0).
- This PR documents the step so re-provisioning keeps it working: runbook **step 1b** + a `BPFCOMPAT_SAMPLE_ARTIFACT` entry in the serve env example.

No code change — `sample.go` already supports the env override.

🤖 Generated with [Claude Code](https://claude.com/claude-code)