### PR TITLE
Declutter demo UI: remove redundant workflow strip (#2)

### DIFF
--- a/internal/api/ui.go
+++ b/internal/api/ui.go
@@ -89,24 +89,6 @@ const uiHTML = `<!doctype html>
     .advanced-settings .section {
       border-bottom: 0;
     }
-    .workflow-strip {
-      display: grid;
-      gap: 8px;
-    }
-    .workflow-steps {
-      display: grid;
-      grid-template-columns: repeat(4, minmax(0, 1fr));
-      gap: 6px;
-    }
-    .workflow-step {
-      border: 1px solid var(--border);
-      border-radius: 6px;
-      background: var(--bg);
-      padding: 7px 8px;
-      font-size: 12px;
-      color: var(--fg-muted);
-      text-align: center;
-    }
     .run-snapshot {
       position: sticky;
       top: 0;
@@ -742,9 +724,6 @@ const uiHTML = `<!doctype html>
         height: auto;
         grid-template-rows: auto;
       }
-      .workflow-steps {
-        grid-template-columns: repeat(2, minmax(0, 1fr));
-      }
       .matrix-counts {
         grid-template-columns: repeat(2, minmax(0, 1fr));
       }
@@ -764,7 +743,6 @@ const uiHTML = `<!doctype html>
       .section {
         padding: 10px;
       }
-      .workflow-steps,
       .run-snapshot-grid,
       .suite-stats,
       .row,
@@ -824,15 +802,6 @@ const uiHTML = `<!doctype html>
           </div>
         </div>
       </div>
-      <div class="section workflow-strip">
-        <div class="workflow-steps">
-          <div class="workflow-step">Targets</div>
-          <div class="workflow-step">BPF</div>
-          <div class="workflow-step">Gate</div>
-          <div class="workflow-step">Matrix</div>
-        </div>
-      </div>
-
       <div class="section">
         <div class="step-title">
           <strong>1. Select Targets</strong>


### PR DESCRIPTION
## Context (#2 — reduce on-load density)
Recon finding worth stating: the demo's heavy panels — advanced metadata, manifest settings, the JSON report, and the runtime/evidence/history surface — are **already** behind `<details>` collapses. So "too much on load" was largely handled; the one genuinely redundant first-paint element was the **workflow strip**.

## Change
The left panel had *three* overlapping progress indicators on load:
1. the live **Gate Snapshot** readiness panel (Targets/BPF/Gate dots + state),
2. a static **workflow strip** (Targets/BPF/Gate/Matrix chips — no state),
3. the **numbered step titles** ("1. Select Targets", "2. Provide BPF"…).

(2) carried no information the other two didn't, so it was pure clutter. This removes it (HTML + CSS rules + two media-query refs). The live readiness snapshot and numbered steps remain; no JS depended on the strip.

## Verify
- `go build`, `go test ./internal/api/`, served locally → 200; `workflow-step` gone from HTML, `Gate Snapshot` retained.

Next: #3 — make the result matrix the visual hero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)