### PR TITLE
Shareable artifacts: compat badge + OG social cards (A+B)

### DIFF
--- a/internal/api/badge.go
+++ b/internal/api/badge.go
@@ -110,7 +110,7 @@ func renderBadgeSVG(label, message, color string) string {
 	em := escapeXML(message)
 	// Standard shields "flat" geometry: text is drawn at 10x scale then scaled
 	// down 0.1 for crisp rendering, with a shadow text underneath.
-	lcx := lw * 5         // label centre, x10
+	lcx := lw * 5 // label centre, x10
 	mcx := (lw + mw/2) * 10
 	ltl := (lw - 10) * 10 // textLength, x10
 	mtl := (mw - 10) * 10

--- a/internal/api/badge.go
+++ b/internal/api/badge.go
@@ -1,0 +1,148 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/kernel-guard/bpfcompat/internal/registry"
+)
+
+// Carbon-aligned badge colours (match the demo/marketing palette).
+const (
+	badgeGreen  = "#42be65"
+	badgeYellow = "#f1c21b"
+	badgeRed    = "#fa4d56"
+	badgeGray   = "#8d8d8d"
+)
+
+// handleBadge serves a shields-style SVG compatibility badge for a run:
+//
+//	/badge/<run_id>.svg  ->  "compat | 6/8 kernels"
+//
+// Public and unauthenticated by design (badges are embedded in READMEs and
+// rendered by GitHub's camo proxy). Only aggregate counts are exposed — never
+// host paths or report internals. An unknown/missing run yields a neutral
+// "unknown" badge with HTTP 200, so an embedded image never appears broken.
+func (s *Server) handleBadge(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		writeError(w, http.StatusMethodNotAllowed, "method not allowed")
+		return
+	}
+	runID := strings.TrimSpace(strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/badge/"), ".svg"))
+
+	label := "compat"
+	message := "unknown"
+	color := badgeGray
+	if runID != "" {
+		if total, passed, requiredFailed, ok := s.badgeCounts(runID); ok {
+			message = fmt.Sprintf("%d/%d kernels", passed, total)
+			switch {
+			case requiredFailed > 0:
+				color = badgeRed
+			case passed < total:
+				color = badgeYellow
+			default:
+				color = badgeGreen
+			}
+		}
+	}
+
+	w.Header().Set("Content-Type", "image/svg+xml;charset=utf-8")
+	w.Header().Set("Cache-Control", "public, max-age=300")
+	w.Header().Set("X-Content-Type-Options", "nosniff")
+	_, _ = w.Write([]byte(renderBadgeSVG(label, message, color)))
+}
+
+// badgeCounts loads a run's report and returns (total, passed, requiredFailed).
+// ok is false when the run is unknown or unreadable.
+func (s *Server) badgeCounts(runID string) (total, passed, requiredFailed int, ok bool) {
+	record, err := registry.GetRunRecord(s.cfg.WorkDir, runID)
+	if err != nil {
+		return 0, 0, 0, false
+	}
+	raw, err := os.ReadFile(filepath.Clean(record.JSONReportPath))
+	if err != nil {
+		return 0, 0, 0, false
+	}
+	var report struct {
+		Targets []struct {
+			Status   string `json:"status"`
+			Required bool   `json:"required"`
+		} `json:"targets"`
+	}
+	if err := json.Unmarshal(raw, &report); err != nil {
+		return 0, 0, 0, false
+	}
+	for _, t := range report.Targets {
+		total++
+		switch {
+		case strings.EqualFold(t.Status, "pass"):
+			passed++
+		case t.Required:
+			requiredFailed++
+		}
+	}
+	if total == 0 {
+		return 0, 0, 0, false
+	}
+	return total, passed, requiredFailed, true
+}
+
+// badgeTextWidth approximates rendered width (px) of Verdana 11 text.
+func badgeTextWidth(s string) int {
+	// ~6.5px average glyph advance is close enough for a badge.
+	w := (len(s)*65 + 5) / 10
+	if w < 10 {
+		w = 10
+	}
+	return w
+}
+
+func renderBadgeSVG(label, message, color string) string {
+	lw := badgeTextWidth(label) + 10
+	mw := badgeTextWidth(message) + 10
+	total := lw + mw
+	el := escapeXML(label)
+	em := escapeXML(message)
+	// Standard shields "flat" geometry: text is drawn at 10x scale then scaled
+	// down 0.1 for crisp rendering, with a shadow text underneath.
+	lcx := lw * 5         // label centre, x10
+	mcx := (lw + mw/2) * 10
+	ltl := (lw - 10) * 10 // textLength, x10
+	mtl := (mw - 10) * 10
+	return fmt.Sprintf(`<svg xmlns="http://www.w3.org/2000/svg" width="%d" height="20" role="img" aria-label="%s: %s">`+
+		`<title>%s: %s</title>`+
+		`<linearGradient id="s" x2="0" y2="100%%"><stop offset="0" stop-color="#bbb" stop-opacity=".1"/><stop offset="1" stop-opacity=".1"/></linearGradient>`+
+		`<clipPath id="r"><rect width="%d" height="20" rx="3" fill="#fff"/></clipPath>`+
+		`<g clip-path="url(#r)">`+
+		`<rect width="%d" height="20" fill="#393939"/>`+
+		`<rect x="%d" width="%d" height="20" fill="%s"/>`+
+		`<rect width="%d" height="20" fill="url(#s)"/>`+
+		`</g>`+
+		`<g fill="#fff" text-anchor="middle" font-family="Verdana,Geneva,DejaVu Sans,sans-serif" font-size="110" text-rendering="geometricPrecision">`+
+		`<text x="%d" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="%d">%s</text>`+
+		`<text x="%d" y="140" transform="scale(.1)" textLength="%d">%s</text>`+
+		`<text x="%d" y="150" fill="#010101" fill-opacity=".3" transform="scale(.1)" textLength="%d">%s</text>`+
+		`<text x="%d" y="140" transform="scale(.1)" textLength="%d">%s</text>`+
+		`</g></svg>`,
+		total, el, em,
+		el, em,
+		total,
+		lw,
+		lw, mw, color,
+		total,
+		lcx, ltl, el,
+		lcx, ltl, el,
+		mcx, mtl, em,
+		mcx, mtl, em,
+	)
+}
+
+func escapeXML(s string) string {
+	r := strings.NewReplacer("&", "&amp;", "<", "&lt;", ">", "&gt;", `"`, "&quot;", "'", "&apos;")
+	return r.Replace(s)
+}

--- a/internal/api/badge_test.go
+++ b/internal/api/badge_test.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+func TestRenderBadgeSVG(t *testing.T) {
+	svg := renderBadgeSVG("compat", "6/8 kernels", badgeGreen)
+	for _, want := range []string{"<svg", "compat", "6/8 kernels", badgeGreen, "</svg>"} {
+		if !strings.Contains(svg, want) {
+			t.Fatalf("badge SVG missing %q:\n%s", want, svg)
+		}
+	}
+	// Special characters in content must be XML-escaped, never raw.
+	if strings.Contains(renderBadgeSVG("a<b", "x&y", badgeRed), "a<b") {
+		t.Fatalf("badge label was not XML-escaped")
+	}
+}
+
+// TestHandleBadgeUnknownRun confirms an unknown run yields a valid neutral
+// badge with HTTP 200 (so embedded README images never break) rather than an
+// error page.
+func TestHandleBadgeUnknownRun(t *testing.T) {
+	s := &Server{cfg: Config{WorkDir: t.TempDir()}}
+	req := httptest.NewRequest(http.MethodGet, "/badge/does-not-exist.svg", http.NoBody)
+	rec := httptest.NewRecorder()
+	s.handleBadge(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", rec.Code)
+	}
+	if ct := rec.Header().Get("Content-Type"); !strings.HasPrefix(ct, "image/svg+xml") {
+		t.Fatalf("expected svg content-type, got %q", ct)
+	}
+	body := rec.Body.String()
+	if !strings.Contains(body, "unknown") || !strings.Contains(body, "<svg") {
+		t.Fatalf("expected unknown badge svg, got: %s", body)
+	}
+}
+
+func TestHandleBadgeRejectsNonGet(t *testing.T) {
+	s := &Server{cfg: Config{WorkDir: t.TempDir()}}
+	req := httptest.NewRequest(http.MethodPost, "/badge/x.svg", http.NoBody)
+	rec := httptest.NewRecorder()
+	s.handleBadge(rec, req)
+	if rec.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", rec.Code)
+	}
+}

--- a/internal/api/demo_result.go
+++ b/internal/api/demo_result.go
@@ -1,8 +1,12 @@
 package api
 
 import (
+	"fmt"
+	"html"
 	"net/http"
 	"strings"
+
+	"github.com/kernel-guard/bpfcompat/internal/registry"
 )
 
 func (s *Server) handleDemoResult(w http.ResponseWriter, r *http.Request) {
@@ -13,7 +17,58 @@ func (s *Server) handleDemoResult(w http.ResponseWriter, r *http.Request) {
 	nonce := generateCSPNonce(r)
 	w.Header().Set("Content-Security-Policy", htmlCSPWithNonce(nonce))
 	w.Header().Set("Content-Type", "text/html; charset=utf-8")
-	_, _ = w.Write([]byte(strings.ReplaceAll(demoResultHTML, "__CSP_NONCE__", nonce)))
+	page := strings.ReplaceAll(demoResultHTML, "__CSP_NONCE__", nonce)
+	page = strings.Replace(page, "__OG_META__", s.resultOGMeta(r), 1)
+	_, _ = w.Write([]byte(page))
+}
+
+// resultOGMeta server-renders Open Graph / Twitter card tags for a shared
+// result link so it unfurls richly in Slack/Discord/social. The summary is
+// computed per run_id at request time (crawlers do not run the page's JS).
+func (s *Server) resultOGMeta(r *http.Request) string {
+	title := "bpfcompat — eBPF kernel compatibility"
+	desc := "Real load/attach evidence across distro kernels, booted in disposable VMs."
+
+	runID := strings.TrimSpace(r.URL.Query().Get("run_id"))
+	if runID != "" {
+		if record, err := registry.GetRunRecord(s.cfg.WorkDir, runID); err == nil {
+			if total, passed, requiredFailed, ok := s.badgeCounts(runID); ok {
+				name := strings.TrimSpace(record.ArtifactName)
+				if name == "" {
+					name = "artifact"
+				}
+				title = fmt.Sprintf("bpfcompat: %s — %d/%d kernels compatible", name, passed, total)
+				if requiredFailed > 0 {
+					desc = fmt.Sprintf("%d required kernel(s) failed. ", requiredFailed) + desc
+				} else {
+					desc = "All required kernels passed. " + desc
+				}
+			}
+		}
+	}
+
+	scheme := "https"
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+		scheme = proto
+	} else if r.TLS == nil {
+		scheme = "http"
+	}
+	pageURL := scheme + "://" + r.Host + r.URL.RequestURI()
+
+	t := html.EscapeString(title)
+	d := html.EscapeString(desc)
+	u := html.EscapeString(pageURL)
+	return strings.Join([]string{
+		`<meta name="description" content="` + d + `">`,
+		`<meta property="og:type" content="website">`,
+		`<meta property="og:site_name" content="bpfcompat">`,
+		`<meta property="og:title" content="` + t + `">`,
+		`<meta property="og:description" content="` + d + `">`,
+		`<meta property="og:url" content="` + u + `">`,
+		`<meta name="twitter:card" content="summary">`,
+		`<meta name="twitter:title" content="` + t + `">`,
+		`<meta name="twitter:description" content="` + d + `">`,
+	}, "\n")
 }
 
 const demoResultHTML = `<!doctype html>
@@ -22,6 +77,7 @@ const demoResultHTML = `<!doctype html>
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>bpfcompat Results</title>
+__OG_META__
   <style nonce="__CSP_NONCE__">
     :root {
       --bg: #0b1220;
@@ -114,7 +170,10 @@ const demoResultHTML = `<!doctype html>
         <h1>Artifact Compatibility Result</h1>
         <div class="muted">Mobile-friendly evidence snapshot: where this BPF object loads, where it fails, and why.</div>
       </div>
-      <button class="btn" type="button" id="refreshBtn">Refresh</button>
+      <div class="row">
+        <button class="btn" type="button" id="shareBtn">Copy link</button>
+        <button class="btn" type="button" id="refreshBtn">Refresh</button>
+      </div>
     </div>
 
     <div class="card">
@@ -403,6 +462,17 @@ const demoResultHTML = `<!doctype html>
     }
 
     byId("refreshBtn").addEventListener("click", loadPage);
+    byId("shareBtn").addEventListener("click", async () => {
+      const btn = byId("shareBtn");
+      const original = btn.textContent;
+      try {
+        await navigator.clipboard.writeText(window.location.href);
+        btn.textContent = "Copied";
+      } catch (e) {
+        btn.textContent = "Copy failed";
+      }
+      setTimeout(() => { btn.textContent = original; }, 1500);
+    });
     loadPage();
   </script>
 </body>

--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -516,6 +516,7 @@ func (s *Server) serve(ctx context.Context) error {
 	mux.HandleFunc("/api/v1/openapi.yaml", handleOpenAPISpec)
 	mux.HandleFunc("/results", s.handleDemoResult)
 	mux.HandleFunc("/demo-result", s.handleDemoResult)
+	mux.HandleFunc("/badge/", s.handleBadge)
 	if metricsEnabled() {
 		mux.Handle("/metrics", s.handleMetrics())
 	}


### PR DESCRIPTION
The "growth loop" half of the next-level web work: turn every run into something people share, so sharing drives discovery.

## B — SVG compatibility badge
`GET /badge/<run_id>.svg` → shields-style **`compat | 6/8 kernels`** from a run's stored report. Green = all required pass, yellow = optional fails, red = required fails, grey = unknown (HTTP 200 so embedded README images never break). Only aggregate counts exposed; Carbon-aligned colours. Teams embed it in their repo.

## A — OG / Twitter social cards on /results
The `/results?run_id=<id>` viewer renders client-side, so shared links had no card. Now the server injects **per-run** Open Graph / Twitter meta at request time (crawlers don't run JS):
- dynamic title — `bpfcompat: <artifact> — <passed>/<total> kernels compatible`
- pass/fail-aware description
- so links unfurl richly in Slack/Discord/social.
- plus a **Copy link** share button on the page.

Together: a shared report link unfurls a branded card → others click → discover the tool → run their own → share. 

## Tests
`go test ./internal/api/` (badge render/escape/unknown-200/405), `go vet`, local serve: badge route returns valid SVG; `/results` emits og:* + twitter:card; `__OG_META__` fully replaced.

Follow-ups in this series: C (live "watch it boot"), D (one-click example + theme toggle). A dynamic rasterised og:image (PNG) is a possible later enhancement; this ships text+title cards which unfurl safely everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)