### PR TITLE
Redact host audit paths from runtime select/fetch responses

### DIFF
--- a/internal/api/server.go
+++ b/internal/api/server.go
@@ -423,6 +423,15 @@ func attachRuntimeAudit(resp map[string]any, workDir string, trace runtime.Decis
 		resp["audit_error"] = err.Error()
 		return
 	}
+	// trace_path / event_stream_path are absolute host paths to the audit files.
+	// They are not retrievable via the API and leak the server's workdir layout,
+	// so strip them from the response under the public/redacted posture (the
+	// runtime delivery endpoints can be anonymous on the demo).
+	if redactRuntimeDetailsEnabled() {
+		audit.TracePath = ""
+		audit.EventStreamPath = ""
+		audit.Event.TracePath = ""
+	}
 	resp["audit"] = audit
 }
 

--- a/internal/api/server_security_test.go
+++ b/internal/api/server_security_test.go
@@ -921,6 +921,34 @@ func TestRuntimeDecisionsRedactTracePath(t *testing.T) {
 	}
 }
 
+// TestAttachRuntimeAuditRedactsHostPaths confirms select/fetch responses do not
+// leak absolute host audit paths when redaction is on (the demo posture, where
+// runtime delivery can be anonymous).
+func TestAttachRuntimeAuditRedactsHostPaths(t *testing.T) {
+	workDir := t.TempDir()
+	trace := runtime.DecisionTrace{Source: "api", Operation: "fetch", ArtifactName: "aegis", Status: "success"}
+
+	t.Setenv(envRedactRuntime, "true")
+	resp := map[string]any{}
+	attachRuntimeAudit(resp, workDir, trace)
+	audit, ok := resp["audit"].(runtime.DecisionPersistResult)
+	if !ok {
+		t.Fatalf("expected audit in response, got %#v", resp["audit"])
+	}
+	if audit.TracePath != "" || audit.EventStreamPath != "" || audit.Event.TracePath != "" {
+		t.Fatalf("expected host paths redacted, got trace=%q stream=%q event=%q",
+			audit.TracePath, audit.EventStreamPath, audit.Event.TracePath)
+	}
+
+	t.Setenv(envRedactRuntime, "false")
+	resp2 := map[string]any{}
+	attachRuntimeAudit(resp2, workDir, trace)
+	audit2 := resp2["audit"].(runtime.DecisionPersistResult)
+	if audit2.TracePath == "" {
+		t.Fatalf("expected trace_path present when redaction is disabled")
+	}
+}
+
 // TestReadEndpointsAllowAuthenticated confirms that supplying the configured
 // API key restores access to the read surface after H-1b's auth gate.
 func TestReadEndpointsAllowAuthenticated(t *testing.T) {

--- a/internal/runtime/audit.go
+++ b/internal/runtime/audit.go
@@ -147,8 +147,8 @@ type DecisionEvent struct {
 
 type DecisionPersistResult struct {
 	DecisionID      string        `json:"decision_id"`
-	TracePath       string        `json:"trace_path"`
-	EventStreamPath string        `json:"event_stream_path"`
+	TracePath       string        `json:"trace_path,omitempty"`
+	EventStreamPath string        `json:"event_stream_path,omitempty"`
 	Event           DecisionEvent `json:"event"`
 }
 


### PR DESCRIPTION
## Security fix
Enabling anonymous runtime delivery (so Select/Fetch work on the public demo) exposed an `audit` block in the select/fetch responses whose `trace_path` / `event_stream_path` are **absolute host paths** (`/var/lib/bpfcompat-demo/...`) — visible to any anonymous visitor.

Strip them when `BPFCOMPAT_API_REDACT_RUNTIME_DETAILS` is set (the demo posture), consistent with the earlier decisions-listing fix. Fields made `omitempty`. Execute remains disabled and unaffected.

## Tests
`TestAttachRuntimeAuditRedactsHostPaths` (redacted when on, present when off); full `internal/api` + `internal/runtime` suites pass; `gofmt`/`vet` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)