### PR TITLE
Add self-hosted health watchdog + monitoring docs (#4)

### DIFF
--- a/docs/hetzner-runbook.md
+++ b/docs/hetzner-runbook.md
@@ -99,6 +99,36 @@ curl -fsS https://bpfcompat.kernelguard.net/api/health
 
 Once green, tear down the Azure VM/resource group to stop any residual billing.
 
+## 6) Uptime monitoring
+
+Two layers — use both:
+
+**a) Self-hosted health watchdog (catches "process up but API hung").**
+Installs a systemd timer that probes `/api/health` every 2 minutes and restarts
+`bpfcompat-serve` if it is unhealthy after retries (and optionally posts to a
+webhook). This complements `Restart=on-failure`, which only reacts to a crashed
+process, not a hung one.
+
+```bash
+ssh root@$HETZNER_HOST '
+  install -m 0755 /opt/bpfcompat-src/scripts/healthcheck.sh /usr/local/bin/bpfcompat-healthcheck
+  install -m 0644 /opt/bpfcompat-src/packaging/systemd/bpfcompat-healthcheck.service /etc/systemd/system/
+  install -m 0644 /opt/bpfcompat-src/packaging/systemd/bpfcompat-healthcheck.timer /etc/systemd/system/
+  # optional alert webhook:
+  # printf "BPFCOMPAT_HEALTH_WEBHOOK=%s\n" "<slack/discord webhook>" > /etc/bpfcompat/healthcheck.env
+  systemctl daemon-reload
+  systemctl enable --now bpfcompat-healthcheck.timer
+  systemctl start bpfcompat-healthcheck.service   # run once now
+'
+```
+
+**b) External monitor (the real safety net — the box can't alert when it's down).**
+Point a free monitor at the public health URL (5-minute setup, no code):
+
+- URL: `https://bpfcompat.kernelguard.net/api/health` — expect HTTP `200`
+- Interval: 1–5 min; alert to email/Slack on failure
+- UptimeRobot, Better Stack, or Cloudflare Health Checks all work
+
 ## Security notes
 
 - Backend never listens publicly: `--addr 127.0.0.1:8080` behind Caddy + `ufw`.

--- a/packaging/systemd/bpfcompat-healthcheck.service
+++ b/packaging/systemd/bpfcompat-healthcheck.service
@@ -1,0 +1,15 @@
+[Unit]
+Description=bpfcompat demo health watchdog (probe + restart on hang)
+Documentation=https://github.com/Kernel-Guard/bpfcompat
+After=bpfcompat-serve.service
+Wants=bpfcompat-serve.service
+
+[Service]
+Type=oneshot
+# Optional overrides (health URL, webhook, etc.) live here if present.
+EnvironmentFile=-/etc/bpfcompat/healthcheck.env
+ExecStart=/usr/local/bin/bpfcompat-healthcheck
+# Restarting the serve unit needs privilege; keep the rest locked down.
+NoNewPrivileges=true
+ProtectHome=true
+ProtectSystem=full

--- a/packaging/systemd/bpfcompat-healthcheck.timer
+++ b/packaging/systemd/bpfcompat-healthcheck.timer
@@ -1,0 +1,13 @@
+[Unit]
+Description=Run the bpfcompat demo health watchdog periodically
+Documentation=https://github.com/Kernel-Guard/bpfcompat
+
+[Timer]
+# First run shortly after boot, then every 2 minutes.
+OnBootSec=2min
+OnUnitActiveSec=2min
+AccuracySec=15s
+Unit=bpfcompat-healthcheck.service
+
+[Install]
+WantedBy=timers.target

--- a/scripts/healthcheck.sh
+++ b/scripts/healthcheck.sh
@@ -1,0 +1,61 @@
+#!/usr/bin/env bash
+set -uo pipefail
+
+# Self-hosted liveness watchdog for the bpfcompat demo. Probes the local health
+# endpoint; if it is unhealthy after a few retries, logs to the journal,
+# optionally posts to a webhook, and restarts the serve unit. Intended to be run
+# on a short systemd timer (see packaging/systemd/bpfcompat-healthcheck.*).
+#
+# This catches "process up but API hung/unhealthy" — a case plain systemd
+# Restart=on-failure does not. It is NOT a substitute for an external monitor
+# (it cannot alert if the whole box/network is down); pair it with one.
+#
+# Config (env):
+#   BPFCOMPAT_HEALTH_URL       default http://127.0.0.1:8080/api/health
+#   BPFCOMPAT_HEALTH_UNIT      systemd unit to restart (default bpfcompat-serve.service)
+#   BPFCOMPAT_HEALTH_RETRIES   probe attempts before acting (default 3)
+#   BPFCOMPAT_HEALTH_RETRY_GAP seconds between attempts (default 3)
+#   BPFCOMPAT_HEALTH_TIMEOUT   per-probe curl timeout seconds (default 5)
+#   BPFCOMPAT_HEALTH_WEBHOOK   optional URL to POST a JSON alert on failure
+#   BPFCOMPAT_HEALTH_RESTART   "true" (default) to restart the unit on failure
+
+URL="${BPFCOMPAT_HEALTH_URL:-http://127.0.0.1:8080/api/health}"
+UNIT="${BPFCOMPAT_HEALTH_UNIT:-bpfcompat-serve.service}"
+RETRIES="${BPFCOMPAT_HEALTH_RETRIES:-3}"
+GAP="${BPFCOMPAT_HEALTH_RETRY_GAP:-3}"
+TIMEOUT="${BPFCOMPAT_HEALTH_TIMEOUT:-5}"
+WEBHOOK="${BPFCOMPAT_HEALTH_WEBHOOK:-}"
+DO_RESTART="${BPFCOMPAT_HEALTH_RESTART:-true}"
+
+log() { echo "bpfcompat-healthcheck: $*" >&2; }
+
+probe() {
+  curl -fsS --max-time "$TIMEOUT" -o /dev/null "$URL"
+}
+
+attempt=1
+while [ "$attempt" -le "$RETRIES" ]; do
+  if probe; then
+    [ "$attempt" -gt 1 ] && log "recovered on attempt ${attempt}"
+    exit 0
+  fi
+  log "health probe failed (attempt ${attempt}/${RETRIES}) for ${URL}"
+  attempt=$((attempt + 1))
+  [ "$attempt" -le "$RETRIES" ] && sleep "$GAP"
+done
+
+ts="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+log "UNHEALTHY after ${RETRIES} attempts at ${ts}"
+
+if [ -n "$WEBHOOK" ]; then
+  payload=$(printf '{"text":"bpfcompat demo health check FAILED at %s (%s)"}' "$ts" "$URL")
+  curl -fsS --max-time 10 -H 'Content-Type: application/json' -d "$payload" "$WEBHOOK" >/dev/null 2>&1 \
+    && log "alert posted to webhook" || log "webhook post failed"
+fi
+
+if [ "$DO_RESTART" = "true" ]; then
+  log "restarting ${UNIT}"
+  systemctl try-restart "$UNIT" && log "restart issued" || log "restart failed"
+fi
+
+exit 1


### PR DESCRIPTION
Final item of the OSS production-readiness track: demo uptime monitoring, two layers.

- **Self-hosted watchdog** — `scripts/healthcheck.sh` + `bpfcompat-healthcheck.{service,timer}`: probes `/api/health` every 2 min, restarts `bpfcompat-serve` if unhealthy after retries, optional webhook alert. Catches *process-up-but-API-hung*, which `Restart=on-failure` doesn't.
- **External monitor** — runbook §6 documents pointing UptimeRobot/Better Stack/Cloudflare at the public health URL (the real safety net, since the box can't alert when it's down).

Hardened unit (NoNewPrivileges, ProtectSystem=full). Being deployed to the live box in parallel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)