### PR TITLE
feat(profiles): scaffold Fedora CoreOS + RHCOS catalog profiles

### DIFF
--- a/docs/profile-catalog.md
+++ b/docs/profile-catalog.md
@@ -38,6 +38,8 @@ This document defines the maintained profile matrices used for compatibility cam
    - `bottlerocket-aws-6.1` (manual image)
    - `flatcar-6.6` (URL-backed image)
    - `talos-6.6` (manual image)
+   - `fedora-coreos-stable-6.14` (manual image; Ignition boot — see below)
+   - `rhcos-4.16-5.14` (manual image, pull-secret gated; Ignition boot — see below)
    - `ubuntu-22.04-5.15-lockdown`
 4. Multi-architecture foundation:
    - `ubuntu-22.04-arm64-5.15` (`aarch64`, requires ARM64-capable runner)
@@ -107,6 +109,7 @@ Optional licensed image source:
 
 - Current VM validator execution path is SSH-based.
 - `talos`, `bottlerocket`, `flatcar`, and `amazon-linux-2-4.14` are cataloged for planning/roadmap and are marked non-blocking in matrix definitions because the current executor cannot run validator payloads on them.
+- `fedora-coreos` and `rhcos` (RHEL CoreOS / OpenShift) are cataloged but **not runnable yet**: both boot via Ignition rather than cloud-init, so the SSH executor cannot provision the validator (same gap as `flatcar`). RHCOS additionally ships through the pull-secret-gated OpenShift release payload. Enabling them needs an Ignition-config bootstrap path in the QEMU executor; until then, the matching RHEL/AlmaLinux 9 (5.14) profile approximates the RHCOS kernel, and Fedora CoreOS is the freely-available stand-in for proving the CoreOS boot path.
 - `rhel-8-4.18` uses NoCloud config-drive bootstrap in the current SSH executor (prefers `cloud-localds` ISO; falls back to local `vvfat` seed).
 - `aarch64`/`arm64` profiles select `qemu-system-aarch64`; `x86_64`/`amd64` profiles select `qemu-system-x86_64`.
 - ARM64 validation requires a matching ARM64-capable self-hosted runner, KVM access, an ARM64 cloud image, and a validator binary built for the guest architecture. The default Azure demo VM is x86_64 and should not be presented as ARM64 validation proof.

--- a/internal/vm/qemu_test.go
+++ b/internal/vm/qemu_test.go
@@ -215,6 +215,11 @@ func TestExecutionTransport(t *testing.T) {
 		{name: "amazon-linux-2-4.14 supported", id: "amazon-linux-2-4.14", distro: "amazon-linux", wantTransport: ExecutionTransportSSH, wantSupported: true},
 		{name: "talos blocked", distro: "talos", wantTransport: ExecutionTransportUnsupported, wantSupported: false, wantInMsg: "no ssh"},
 		{name: "bottlerocket blocked", distro: "bottlerocket", wantTransport: ExecutionTransportUnsupported, wantSupported: false, wantInMsg: "ssh"},
+		{name: "flatcar blocked", distro: "flatcar", wantTransport: ExecutionTransportUnsupported, wantSupported: false, wantInMsg: "ignition"},
+		{name: "fedora-coreos blocked", distro: "fedora-coreos", wantTransport: ExecutionTransportUnsupported, wantSupported: false, wantInMsg: "ignition"},
+		{name: "fcos alias blocked", distro: "FCOS", wantTransport: ExecutionTransportUnsupported, wantSupported: false, wantInMsg: "ignition"},
+		{name: "rhcos blocked", distro: "rhcos", wantTransport: ExecutionTransportUnsupported, wantSupported: false, wantInMsg: "ignition"},
+		{name: "rhel-coreos alias blocked", distro: "rhel-coreos", wantTransport: ExecutionTransportUnsupported, wantSupported: false, wantInMsg: "ignition"},
 	}
 
 	for _, tt := range tests {

--- a/internal/vm/transport.go
+++ b/internal/vm/transport.go
@@ -24,6 +24,10 @@ func ExecutionTransport(profile Profile) (transport string, supported bool, reas
 		return ExecutionTransportUnsupported, false, "Bottlerocket requires control/admin container workflows; current validator runner requires direct SSH transport."
 	case "flatcar":
 		return ExecutionTransportUnsupported, false, "Flatcar images in this matrix require Ignition-style bootstrap; current validator runner depends on cloud-init+SSH provisioning."
+	case "fedora-coreos", "fcos":
+		return ExecutionTransportUnsupported, false, "Fedora CoreOS boots via Ignition (not cloud-init); current validator runner depends on cloud-init+SSH provisioning."
+	case "rhcos", "rhel-coreos":
+		return ExecutionTransportUnsupported, false, "RHEL CoreOS (OpenShift) boots via Ignition and ships through the pull-secret-gated OpenShift release payload; current validator runner depends on cloud-init+SSH provisioning."
 	default:
 		return ExecutionTransportSSH, true, ""
 	}

--- a/vm/profiles/fedora-coreos-stable-6.14.yaml
+++ b/vm/profiles/fedora-coreos-stable-6.14.yaml
@@ -1,0 +1,30 @@
+# Fedora CoreOS (stable stream) — cataloged / roadmap, NOT runnable today.
+#
+# FCOS is the freely-available cousin of RHEL CoreOS (RHCOS) and the runnable
+# stand-in for proving the CoreOS boot path: same Ignition-based first boot,
+# same rpm-ostree immutable layout, no Red Hat pull secret required.
+#
+# Why it's not runnable yet: FCOS boots via Ignition, not cloud-init, so the
+# current SSH executor cannot inject the validator + SSH key. internal/vm
+# ExecutionTransport() reports this profile as unsupported (see the `fcos`
+# transport reason). Enabling it needs an Ignition-config bootstrap path in the
+# QEMU executor (-fw_cfg name=opt/com.coreos/config).
+#
+# Image: distributed as a versioned, xz-compressed qcow2 via the stream
+# metadata (https://builds.coreos.fedoraproject.org/streams/stable.json) or
+# `coreos-installer download -p qemu -s stable`. Decompress to the local_path
+# below; there is no stable plain-qcow2 "latest" URL, hence local_path only.
+id: fedora-coreos-stable-6.14
+distro: fedora-coreos
+version: "stable"
+kernel_family: "6.14"
+arch: x86_64
+image:
+  local_path: "vm/cache/fedora-coreos-stable.qcow2"
+boot:
+  memory_mb: 2048
+  cpus: 2
+validator:
+  path: "/usr/local/bin/bpfcompat-validator"
+capabilities:
+  expected_btf: true

--- a/vm/profiles/rhcos-4.16-5.14.yaml
+++ b/vm/profiles/rhcos-4.16-5.14.yaml
@@ -1,0 +1,31 @@
+# RHEL CoreOS (OpenShift 4.16) — cataloged / roadmap, NOT runnable today.
+#
+# RHCOS is the immutable node OS for OpenShift. Its kernel is the RHEL 9.4
+# kernel (5.14, heavily backported), so for pure BPF-load questions a RHEL-9 /
+# AlmaLinux-9 profile already approximates it closely. RHCOS is the requested
+# "tricky target" because of how it boots and ships, not because of the kernel.
+#
+# Why it's not runnable yet (two gaps):
+#   1. Boot: RHCOS boots via Ignition, not cloud-init — same executor gap as
+#      Fedora CoreOS / Flatcar. ExecutionTransport() reports it unsupported.
+#   2. Image: RHCOS qcow2 is distributed through the OpenShift release payload
+#      and is pull-secret gated; obtain it via the matching openshift-install /
+#      `oc adm release` for the 4.16 release, then stage at the local_path below.
+#
+# Pragmatic interim: validate against the matching RHEL/AlmaLinux 9 (5.14)
+# profile, which shares the kernel + backports. A true RHCOS boot is the
+# differentiated follow-up once the Ignition bootstrap path lands.
+id: rhcos-4.16-5.14
+distro: rhcos
+version: "4.16"
+kernel_family: "5.14"
+arch: x86_64
+image:
+  local_path: "vm/cache/rhcos-4.16.qcow2"
+boot:
+  memory_mb: 2048
+  cpus: 2
+validator:
+  path: "/usr/local/bin/bpfcompat-validator"
+capabilities:
+  expected_btf: true


### PR DESCRIPTION
## What

Scaffolds CoreOS-family kernel targets in the profile catalog, prompted by a maintainer request (Angelo Puglisi: *"I'd love if it could check like RHCOS, those are the tricky ones"*).

- `vm/profiles/fedora-coreos-stable-6.14.yaml` — Fedora CoreOS, the freely-available CoreOS stand-in (no Red Hat pull secret).
- `vm/profiles/rhcos-4.16-5.14.yaml` — RHEL CoreOS / OpenShift 4.16 (RHEL 9.4 kernel, 5.14).

## Honest status: cataloged, **not runnable yet**

These are roadmap entries, not a "supported" claim — same posture as the existing `talos` / `bottlerocket` / `flatcar` profiles. `ExecutionTransport()` marks both unsupported because:

1. **Boot** — CoreOS boots via **Ignition**, not cloud-init, so the SSH executor can't inject the validator + key (identical gap to `flatcar`). Enabling them needs an Ignition-config bootstrap path in the QEMU executor.
2. **Image (RHCOS)** — distributed through the pull-secret-gated OpenShift release payload.

## Why it's still useful now

The RHCOS *kernel* is the RHEL 9.4 kernel (5.14, heavily backported), so the matching **RHEL / AlmaLinux 9 (5.14)** profile already approximates it for BPF-load questions. **Fedora CoreOS** is the freely-available cousin and the natural runnable stand-in to prove the CoreOS/Ignition boot path before tackling the gated RHCOS image.

## Changes

- Two profile YAMLs (local_path-based, with header comments documenting image acquisition + the Ignition gap).
- `internal/vm/transport.go`: `fedora-coreos`/`fcos` and `rhcos`/`rhel-coreos` → unsupported with Ignition reasons.
- `internal/vm/qemu_test.go`: extended the `ExecutionTransport` table (adds flatcar + the four CoreOS cases).
- `docs/profile-catalog.md`: tier-3 entries + a Transport Notes paragraph.

`go test ./internal/vm/...` green (profile catalog load/validate + transport).

🤖 Generated with [Claude Code](https://claude.com/claude-code)