### PR TITLE
fix(profiles): include CoreOS profiles in tier3 matrix (catalog↔matrix consistency)

### DIFF
--- a/docs/profile-catalog.md
+++ b/docs/profile-catalog.md
@@ -95,6 +95,8 @@ This document defines the maintained profile matrices used for compatibility cam
   - `vm/cache/linux-mainline-5.6.qcow2`
   - `vm/cache/bottlerocket-aws-6.1.qcow2`
   - `vm/cache/talos-6.6.qcow2`
+  - `vm/cache/fedora-coreos-stable.qcow2` (also Ignition-gated — see Transport Notes)
+  - `vm/cache/rhcos-4.16.qcow2` (pull-secret + Ignition-gated — see Transport Notes)
 
 Strict commands can run now:
 

--- a/matrices/tier3-cloud-native.yaml
+++ b/matrices/tier3-cloud-native.yaml
@@ -6,5 +6,9 @@ profiles:
     required: false
   - id: talos-6.6
     required: false
+  - id: fedora-coreos-stable-6.14
+    required: false
+  - id: rhcos-4.16-5.14
+    required: false
   - id: ubuntu-22.04-5.15-lockdown
     required: true


### PR DESCRIPTION
Fixes an inconsistency introduced in #48: `docs/profile-catalog.md` lists `fedora-coreos-stable-6.14` and `rhcos-4.16-5.14` under **Tier 3**, but `matrices/tier3-cloud-native.yaml` did not include them — even though the sibling non-runnable profiles (Bottlerocket, Talos, Flatcar) are in that matrix as `required: false`.

## Change
- Add both CoreOS profiles to `matrices/tier3-cloud-native.yaml` as `required: false`, matching the sibling convention.
- List their missing cache images in the catalog's strict-mode section.

## Not changed (deliberately)
- **Runnability** — CoreOS stays Ignition-gated; `ExecutionTransport()` still returns `unsupported`, so nothing claims RHCOS/FCOS actually boot and load/attach. The matrix entries are non-blocking.
- **README "Distributions covered"** — RHCOS/OpenShift remains absent, because there is no real runnable support. (Correct as-is.)

## Verify
- All 6 matrix profile ids resolve to `vm/profiles/<id>.yaml`.
- `go test ./internal/matrix ./internal/vm ./internal/runner` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)