### PR TITLE
chore(release): cut v0.2.0 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once a
 
 ## [Unreleased]
 
+## [0.2.0] - 2026-06-27
+
 ### Added
 - aarch64 VM support: the QEMU executor now supplies aarch64 UEFI firmware
   (AAVMF pflash; `BPFCOMPAT_AARCH64_UEFI_CODE`/`_VARS`) and uses TCG software


### PR DESCRIPTION
Rolls `[Unreleased]` into **`[0.2.0]`** ahead of tagging.

Highlights since v0.1.6:
- **New public API:** embeddable `pkg/bpfcompat` (`ValidateBeforeLoad`) for pre-load gating.
- **New platform:** OpenShift/CoreOS — Fedora CoreOS runnable, RHCOS opt-in with a real multi-version × multi-arch evidence matrix.
- **aarch64 VM boot:** UEFI firmware (AAVMF pflash) + cross-arch TCG fallback.
- OCI gadget loading + `--quick`, program auto-typing, manifest program-type override, generic inner-map fixup, runtime-sized map auto-sizing.

After merge I'll tag `v0.2.0` on the merge commit; the release workflow builds + signs + attaches assets and creates the GitHub release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)