### PR TITLE
docs: version consistency — bump action refs to @v0.2.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -511,7 +511,7 @@ or the Firecracker lane. See
 Suite mode (recommended — gates the whole collection):
 
 ```yaml
-- uses: Kernel-Guard/bpfcompat@v0.1.6
+- uses: Kernel-Guard/bpfcompat@v0.2.0
   with:
     suite: suites/project.yaml
     suite-out: reports/suite.json
@@ -525,7 +525,7 @@ are alive and adds the result to the suite-level collection matrix.
 Single artifact:
 
 ```yaml
-- uses: Kernel-Guard/bpfcompat@v0.1.6
+- uses: Kernel-Guard/bpfcompat@v0.2.0
   with:
     artifact: path/to/program.bpf.o
     manifest: path/to/manifest.yaml

--- a/docs/case-study-falco-modern-bpf.md
+++ b/docs/case-study-falco-modern-bpf.md
@@ -49,7 +49,7 @@ That is the difference between "❌ it broke" and "❌ ring buffer isn't availab
 
 ```bash
 # In CI (GitHub Action), against your kernel matrix:
-- uses: Kernel-Guard/bpfcompat@v0.1.6
+- uses: Kernel-Guard/bpfcompat@v0.2.0
   with:
     artifact: build/bpf_probe.o
     matrix: matrices/mvp.yaml

--- a/docs/external-ci-proof.md
+++ b/docs/external-ci-proof.md
@@ -17,7 +17,7 @@ that compatibility failures block CI with `rc=2`.
   - <https://github.com/ErenAri/bpfcompat-external-ci-proof/blob/main/.github/workflows/external-negative.yml>
   - <https://github.com/ErenAri/bpfcompat-external-ci-proof/blob/main/.github/workflows/external-suite.yml>
 
-Public repositories can reference `Kernel-Guard/bpfcompat@v0.1.3` directly.
+Public repositories can reference `Kernel-Guard/bpfcompat@v0.2.0` directly.
 
 ## Source Refs Validated
 

--- a/docs/project-compatibility-suite.md
+++ b/docs/project-compatibility-suite.md
@@ -114,7 +114,7 @@ Single-artifact mode remains supported. Suite mode is enabled by setting
 `suite`:
 
 ```yaml
-- uses: Kernel-Guard/bpfcompat@v0.1.3
+- uses: Kernel-Guard/bpfcompat@v0.2.0
   with:
     suite: suites/dev-functional.yaml
     suite-out: reports/bpfcompat-suite.json

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest          # exposes /dev/kvm for KVM acceleration
     steps:
       - uses: actions/checkout@v4
-      - uses: Kernel-Guard/bpfcompat@v0.1.6
+      - uses: Kernel-Guard/bpfcompat@v0.2.0
         with:
           artifact: build/program.bpf.o     # your compiled object
           matrix: matrices/mvp.yaml          # the kernels you support
@@ -57,7 +57,7 @@ What you get:
 Shipping a whole product? Use **suite mode** to gate a collection in one run:
 
 ```yaml
-      - uses: Kernel-Guard/bpfcompat@v0.1.6
+      - uses: Kernel-Guard/bpfcompat@v0.2.0
         with:
           suite: suites/project.yaml
           suite-out: reports/suite.json


### PR DESCRIPTION
Integrity sweep across docs + frontend after the v0.2.0 release.

**Found + fixed:** several forward-looking `uses: Kernel-Guard/bpfcompat@...` examples still pinned old versions (@v0.1.6 in README ×2, quickstart ×2, Falco case study; @v0.1.3 in the suite doc and external-CI proof). All bumped to **@v0.2.0**. No historical run records changed.

**Verified consistent (no changes needed):**
- All README internal doc links resolve (40+ checked).
- RHCOS facts match across `docs/evidence-rhcos.md`, `docs/report-rhcos-summary.json`, and the README (kernels 5.14.0-284/-427 + aarch64; OCP 4.14/4.16/4.18).
- RHCOS correctly **absent** from the README "Distributions covered" table.
- `ValidateBeforeLoad(ctx, path)` signature consistent across README, example, pkg docs.
- Frontend: `BPFCOMPAT_VERSION`=v0.2.0, all snippets use it dynamically, RHCOS not in the covered grid, exactly one "three ways" section, tsc + i18n parity green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)