### PR TITLE
docs: surface command mode as a core feature + soften Falco loader claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -208,7 +208,11 @@ failing.
 ## Proof: a real Falco probe catches a real regression
 
 `bpfcompat` validates Falco's `modern_bpf` probe (`bpf_probe.o`, ~64 programs)
-exactly as Falco's own loader runs it, across a 5-kernel matrix:
+**the way Falco's `libpman` loads it** — runtime-sized maps, helper-gated program
+variants, and trial-probed BPF iterators, declared in a manifest so a plain
+libbpf load doesn't undercount support. (This *mirrors* libpman's loader
+contract; it is not Falco's loader binary itself — to run that exact binary, use
+[command mode](docs/command-validation.md).) Across a 5-kernel matrix:
 
 | Profile | Host kernel | Status | Why |
 |---|---|---|---|
@@ -248,8 +252,17 @@ not a production runtime loader and it is not a production multi-tenant SaaS.
 Implemented:
 
 - VM-backed `.bpf.o` validation through QEMU/KVM cloud images.
+- **Command/binary validation** (`bpfcompat test --command`) — run *your own*
+  loader binary/command inside each kernel VM and take its **exit code** as the
+  per-kernel verdict. The bundled validator is **not** used in this mode; this
+  tests the real userspace loader path. See
+  [docs/command-validation.md](docs/command-validation.md).
+- **Library of known-tricky vendor kernels** (`matrices/quirk-library.yaml`) —
+  the kernels where "version ≠ feature support" bites; run a `.bpf.o` or your
+  own loader against the whole set. See
+  [docs/kernel-quirk-library.md](docs/kernel-quirk-library.md).
 - C/libbpf validator that records load, attach, BTF, CO-RE, map, program, and
-  capability evidence.
+  capability evidence (the default `.bpf.o` flow).
 - Failure classification for common compatibility cases such as missing BTF,
   CO-RE relocation failures, unsupported map types, unsupported attach types,
   and unsupported program types.

--- a/docs/case-study-falco-modern-bpf.md
+++ b/docs/case-study-falco-modern-bpf.md
@@ -13,9 +13,12 @@ recognizable artifact: Falco's `modern_bpf` probe (`bpf_probe.o`).
   sha256 `4895177ced5618d22fd40c1d69be80c7f16fc28f9552f0eff5fdbf682bbd2722`.
 - **Validation mode:** load + attach, inside disposable QEMU/KVM VMs running each
   exact kernel.
-- **Loaded exactly as libpman does** — runtime-sized maps, helper-gated program
-  variants, trial-probed BPF iterators (declared in a manifest) — so a generic
-  libbpf load does not undercount support.
+- **Loaded mirroring libpman's loader contract** — runtime-sized maps,
+  helper-gated program variants, trial-probed BPF iterators (declared in a
+  manifest) — so a generic libbpf load does not undercount support. This
+  reproduces *how* libpman loads the object; it is not Falco's loader binary
+  itself (for that, use command mode — see
+  [command-validation.md](command-validation.md)).
 
 ## Result
 


### PR DESCRIPTION
Follow-up to #65 — fixes how the work *reads*, not the code.

### 1. Command mode wasn't surfaced as a core feature
The README "Implemented:" list led with `.bpf.o` validation and never mentioned
`bpfcompat test --command`, so the binary/loader-path capability (which #65
actually shipped) read as missing. Added explicit bullets making clear:
- command mode takes **your loader's exit code** as the verdict;
- **the bundled C/libbpf validator is not used** — it tests the real userspace
  loader path (distinct from `behavior` mode, which layers a smoke command on top
  of a validator load);
- plus the known-tricky kernel library.

### 2. Softened an overclaim
> ~~"validates Falco's modern_bpf probe **exactly as Falco's own loader runs it**"~~

bpfcompat **mirrors libpman's loader contract** (runtime-sized maps, helper-gated
program variants, trial-probed iterators declared in a manifest) — it does not run
Falco's loader binary. Reworded in the README and the Falco case study, and point
at command mode as the way to run that exact binary.

Docs-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)