### PR TITLE
fix(ci): install cloud-image-utils in the publish lane (cidata seed ISO)

### DIFF
--- a/.github/workflows/compatibility-matrix-publish.yml
+++ b/.github/workflows/compatibility-matrix-publish.yml
@@ -65,9 +65,14 @@ jobs:
         run: |
           set -euo pipefail
           sudo apt-get update
+          # cloud-image-utils provides cloud-localds: the RHEL-family/Amazon/
+          # Oracle/SUSE profiles deliver cloud-init via a cidata seed ISO, and
+          # without cloud-localds bpfcompat falls back to a vvfat config drive
+          # that those guests never boot from (0-byte serial, SSH timeout) —
+          # exactly the 7 infra_errors in runs 28555255212 / 28584050911.
           sudo apt-get install -y --no-install-recommends \
-            qemu-system-x86 qemu-utils clang llvm libbpf-dev libelf-dev zlib1g-dev \
-            pkg-config jq
+            qemu-system-x86 qemu-utils cloud-image-utils clang llvm libbpf-dev \
+            libelf-dev zlib1g-dev pkg-config jq
 
       - name: Free hosted-runner disk space
         # The 11 quirk-library images total ~11 GB; the stock runner has ~14 GB
@@ -163,6 +168,7 @@ jobs:
             reports/quirk-library-*.json
             reports/quirk-library-*.md
             .bpfcompat/runs/**/targets/**/serial.log
+            .bpfcompat/runs/**/targets/**/qemu.log
             .bpfcompat/runs/**/targets/**/libbpf.log
             .bpfcompat/runs/**/targets/**/validator-result.json
             .bpfcompat/runs/**/targets/**/validator.stderr


### PR DESCRIPTION
Second publish run ([28584050911](https://github.com/Kernel-Guard/bpfcompat/actions/runs/28584050911)) failed identically even with the prefetch fix — same 7 targets, but this time the evidence pinpointed it: their **serial logs are 0 bytes**. The guests never booted at all; downloads were never the (whole) problem.

## Root cause
`needsCIDATASeed` routes RHEL-family/Amazon/Oracle/SUSE profiles through a **cidata seed ISO** built with `cloud-localds`, silently falling back to a **vvfat config drive** when it's missing — and those guests never boot from the vvfat fallback on the hosted runner. The runner doesn't ship `cloud-localds`; dev boxes do (why all 11 profiles boot locally). The 7 failing targets are exactly the `needsCIDATASeed` distro list; the 4 Ubuntu/Debian targets use the NoCloud net seed and validated fine in both runs.

## Fix
- `apt-get install cloud-image-utils` (provides `cloud-localds`) with a comment explaining why.
- Add `qemu.log` to the evidence artifact allowlist — its absence made this diagnosis harder than it needed to be.

Will re-dispatch after merge; third time with both fixes (prefetch + seed ISO) should be the real end-to-end proof.

🤖 Generated with [Claude Code](https://claude.com/claude-code)