### PR TITLE
docs: bpfcompat now runs upstream in falcosecurity/libs CI

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,12 @@ bpfcompat test --artifact ghcr.io/inspektor-gadget/gadget/trace_open:latest --qu
 **Quickstart & trust model:** [docs/quickstart.md](docs/quickstart.md) — gate it in CI
 in ~10 minutes; self-hosted-first, your artifact never leaves your runner.
 
+**Runs upstream:** [falcosecurity/libs](https://github.com/falcosecurity/libs)
+merged a scheduled bpfcompat compatibility lane for Falco's `modern_bpf` probe,
+driven by Falco's real loader binary
+([falcosecurity/libs#3024](https://github.com/falcosecurity/libs/pull/3024),
+[workflow](https://github.com/falcosecurity/libs/blob/master/.github/workflows/bpfcompat-compatibility.yml)).
+
 ## Why not just rely on CO-RE / BTFHub?
 
 CO-RE makes a `.bpf.o` *portable in principle*; it does not guarantee it will
@@ -241,6 +247,15 @@ The red `5.4` row is the point: a kernel below Falco's real floor is flagged
 *before* shipping, with the exact mechanism (`ringbuf_maps` create returns
 `-EINVAL`) and remediation — not a generic "it broke." Reproduce this matrix
 locally; see [`docs/falco-parity.md`](docs/falco-parity.md).
+
+This proof graduated to upstream CI:
+[falcosecurity/libs#3024](https://github.com/falcosecurity/libs/pull/3024)
+merged a scheduled lane into `falcosecurity/libs` that builds Falco's real
+userspace loader (`scap-open`, statically linked, modern_bpf probe embedded)
+from the tree under test and runs it inside each matrix kernel VM via
+[command mode](docs/command-validation.md) — the loader's exit code is the
+per-kernel verdict, with no manifest to keep in sync
+([workflow](https://github.com/falcosecurity/libs/blob/master/.github/workflows/bpfcompat-compatibility.yml)).
 
 ## Validate a published gadget in one command
 

--- a/docs/case-study-falco-modern-bpf.md
+++ b/docs/case-study-falco-modern-bpf.md
@@ -48,11 +48,26 @@ act on:
 That is the difference between "❌ it broke" and "❌ ring buffer isn't available on
 5.4 — ship a non-ringbuf fallback for that band." The output is a decision, not a log.
 
+## Upstream: this check now runs in falcosecurity/libs CI
+
+On 2026-07-15, [falcosecurity/libs#3024](https://github.com/falcosecurity/libs/pull/3024)
+merged a scheduled bpfcompat compatibility lane into `falcosecurity/libs`
+([workflow](https://github.com/falcosecurity/libs/blob/master/.github/workflows/bpfcompat-compatibility.yml)).
+It goes one step further than the manifest-mirror approach documented above:
+it builds Falco's real userspace loader (`scap-open`, statically linked with
+the modern_bpf probe skeleton embedded) from the tree under test and runs it
+inside each matrix kernel VM via [command mode](command-validation.md)
+(`scap-open --modern_bpf --num_events 10`). The loader's exit code is the
+per-kernel verdict — `scap_open()` exercises libpman's full load path
+(runtime-sized maps, helper-gated program variants, trial-probed iterators,
+attach), then captures a bounded number of events — so there is no manifest to
+keep in sync with the loader: the loader is the contract.
+
 ## Reproduce it
 
 ```bash
 # In CI (GitHub Action), against your kernel matrix:
-- uses: Kernel-Guard/bpfcompat@v0.2.0
+- uses: Kernel-Guard/bpfcompat@v0.3.0
   with:
     artifact: build/bpf_probe.o
     matrix: matrices/mvp.yaml

--- a/docs/command-validation.md
+++ b/docs/command-validation.md
@@ -122,6 +122,13 @@ The `command` string is passed to the runner through the environment (never
 interpolated into the action's shell), and inside the guest it is executed as a
 single quoted `bash -lc` operand, exactly as in the CLI flow.
 
+Real-world example: `falcosecurity/libs` runs exactly this flow in its
+scheduled CI — it builds Falco's `scap-open` loader statically (modern_bpf
+probe skeleton embedded) and validates it per kernel with
+`command: $BPFCOMPAT_BIN --modern_bpf --num_events 10`
+([falcosecurity/libs#3024](https://github.com/falcosecurity/libs/pull/3024),
+[workflow](https://github.com/falcosecurity/libs/blob/master/.github/workflows/bpfcompat-compatibility.yml)).
+
 ## Scope / limitations (first cut)
 
 - Command mode currently supports the **`vm`** runner only (the default). It is


### PR DESCRIPTION
## What

falcosecurity/libs#3024 merged on 2026-07-15: a scheduled CI lane in `falcosecurity/libs` builds Falco's real userspace loader (`scap-open`, statically linked, modern_bpf probe embedded) and validates it inside each matrix kernel VM via bpfcompat command mode ([workflow](https://github.com/falcosecurity/libs/blob/master/.github/workflows/bpfcompat-compatibility.yml)).

Update the docs to reflect it:

- **README**: "Runs upstream" callout near the top + graduate the "Proof: a real Falco probe" section from standalone evidence to merged upstream CI.
- **docs/case-study-falco-modern-bpf.md**: new "Upstream" section explaining the scap-open command-mode lane (the loader is the contract — no manifest to keep in sync); bump the stale `v0.2.0` action pin in the reproduce snippet to `v0.3.0`.
- **docs/command-validation.md**: real-world example under the GitHub Action section.

## Verification

The exact merged workflow was dress-rehearsed on a fork (`ErenAri/libs` run [29422004424](https://github.com/ErenAri/libs/actions/runs/29422004424)): scap-open static build + 3-kernel matrix all pass (`ubuntu-22.04-5.15` / `debian-12-6.1` / `ubuntu-24.04-6.8`) — after adding `libbpf-dev`/`zlib1g-dev` to the runner deps (upstream fix branch prepared separately). Wording stays factual (a workflow exists and runs) — no endorsement claims.

🤖 Generated with [Claude Code](https://claude.com/claude-code)