### PR TITLE
ci: bump pinned Go to 1.25.12 (GO-2026-5856)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ concurrency:
   cancel-in-progress: true
 
 env:
-  GO_VERSION: "1.25.11"
+  GO_VERSION: "1.25.12"
 
 jobs:
   test:

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -39,7 +39,7 @@ jobs:
       - name: Set up Go
         uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
           cache: true
 
       - name: Initialize CodeQL

--- a/.github/workflows/kernel-freshness.yml
+++ b/.github/workflows/kernel-freshness.yml
@@ -32,7 +32,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
           cache: true
 
       - name: Build CLI

--- a/.github/workflows/profile-catalog-maintenance.yml
+++ b/.github/workflows/profile-catalog-maintenance.yml
@@ -20,7 +20,7 @@ jobs:
       - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0
       - uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
-          go-version: "1.25.11"
+          go-version: "1.25.12"
           cache: true
 
       - name: Build CLI

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -33,7 +33,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  GO_VERSION: "1.25.11"
+  GO_VERSION: "1.25.12"
 
 jobs:
   build-and-sign:

--- a/.github/workflows/stability-gate.yml
+++ b/.github/workflows/stability-gate.yml
@@ -26,7 +26,7 @@ concurrency:
   cancel-in-progress: false
 
 env:
-  GO_VERSION: "1.25.11"
+  GO_VERSION: "1.25.12"
 
 jobs:
   stability:


### PR DESCRIPTION
govulncheck fails every PR since [GO-2026-5856](https://pkg.go.dev/vuln/GO-2026-5856) (Encrypted Client Hello privacy leak in `crypto/tls`) was published: it affects go1.25.11 (our pinned toolchain) and is fixed in go1.25.12. Reachable via the API server / cloud registry / freshness fetcher call paths, so the finding is real, not noise.

Bumps `GO_VERSION`/`go-version` in all six workflows that pin it (ci, codeql, release-artifacts, stability-gate, kernel-freshness, profile-catalog-maintenance).

Unblocks #81.

🤖 Generated with [Claude Code](https://claude.com/claude-code)