### PR TITLE
feat(action): use prebuilt release binaries for commit-SHA pins

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -72,7 +72,7 @@ inputs:
     required: false
     default: "true"
   prebuilt:
-    description: Use prebuilt release binaries when the action is pinned to a release tag ("auto"), or always build from source ("never"). Downloads are checksum-verified against the release SHA256SUMS.
+    description: Use prebuilt release binaries when the action is pinned to a release tag or to a commit SHA that matches a release tag ("auto"), or always build from source ("never"). Downloads are checksum-verified against the release SHA256SUMS.
     required: false
     default: "auto"
   binary:
@@ -89,10 +89,30 @@ runs:
       shell: bash
       env:
         ACTION_REF: ${{ github.action_ref }}
+        GITHUB_API_TOKEN: ${{ github.token }}
       run: |
         set -euo pipefail
         echo "resolved=false" >> "$GITHUB_OUTPUT"
         ref="${ACTION_REF:-}"
+        if [[ "$ref" =~ ^[0-9a-f]{40}$ ]] && command -v jq >/dev/null 2>&1; then
+          # Pinned by commit SHA (the recommended way to pin third-party
+          # actions). Resolve the commit to the release tag that points at it
+          # so SHA-pinned consumers still get prebuilt binaries instead of
+          # silently requiring libbpf build deps on the runner. Any API
+          # hiccup or no matching tag falls through to the source build.
+          tags_json="$(curl -fsSL --retry 2 \
+            -H "Authorization: Bearer ${GITHUB_API_TOKEN}" \
+            -H "Accept: application/vnd.github+json" \
+            "https://api.github.com/repos/Kernel-Guard/bpfcompat/tags?per_page=100" || true)"
+          resolved_tag="$(printf '%s' "$tags_json" \
+            | jq -r --arg sha "$ref" \
+              '[.[] | select(.commit.sha == $sha) | .name | select(test("^v[0-9]"))][0] // empty' \
+            2>/dev/null || true)"
+          if [[ -n "$resolved_tag" ]]; then
+            echo "Commit ${ref} is release ${resolved_tag}; using its prebuilt binaries."
+            ref="$resolved_tag"
+          fi
+        fi
         if [[ ! "$ref" =~ ^v[0-9] ]]; then
           echo "Action not pinned to a release tag (ref: ${ref:-none}); building from source."
           exit 0

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest          # exposes /dev/kvm for KVM acceleration
     steps:
       - uses: actions/checkout@v4
-      - uses: Kernel-Guard/bpfcompat@v0.2.0
+      - uses: Kernel-Guard/bpfcompat@v0.3.0
         with:
           artifact: build/program.bpf.o     # your compiled object
           matrix: matrices/mvp.yaml          # the kernels you support
@@ -57,7 +57,7 @@ What you get:
 Shipping a whole product? Use **suite mode** to gate a collection in one run:
 
 ```yaml
-      - uses: Kernel-Guard/bpfcompat@v0.2.0
+      - uses: Kernel-Guard/bpfcompat@v0.3.0
         with:
           suite: suites/project.yaml
           suite-out: reports/suite.json
@@ -66,8 +66,11 @@ Shipping a whole product? Use **suite mode** to gate a collection in one run:
 
 The Action is on the
 [GitHub Marketplace](https://github.com/marketplace/actions/bpfcompat-ebpf-compatibility-gate).
-Pinning to a release tag uses checksum-verified, attested prebuilt binaries
-([verifying releases](verifying-releases.md)); otherwise it builds from source.
+Pinning to a release tag — or to the commit SHA a release tag points at — uses
+checksum-verified, attested prebuilt binaries
+([verifying releases](verifying-releases.md)); otherwise it builds from source,
+which needs `libbpf-dev`, `libelf-dev`, `zlib1g-dev`, and `pkg-config` on the
+runner.
 
 ## 2. Run it locally (CLI)
 


### PR DESCRIPTION
## Problem

Pinning third-party actions by full commit SHA is the recommended practice (and what falcosecurity maintainers explicitly asked for in falcosecurity/libs#3024) — but the action's prebuilt-binary resolution only matched `v*` tag refs. A SHA pin silently fell back to **building the validator from source**, which fails on any runner without `libbpf-dev`:

```
src/main.c:3:10: fatal error: bpf/bpf.h: No such file or directory
```

This is exactly what broke the falcosecurity/libs lane's first dress-rehearsal run ([failing run](https://github.com/ErenAri/libs/actions/runs/29421614293), stopgap upstream fix falcosecurity/libs#3055).

## Fix

When `github.action_ref` is a 40-hex commit SHA, resolve it to the release tag pointing at that commit via the tags API (authenticated with the workflow's `github.token` to avoid shared-runner rate limits) and use that release's checksum-verified prebuilt binaries.

Fallback behavior is unchanged and graceful: no matching tag, missing `jq`, or any API failure → existing build-from-source path; `prebuilt: never` still forces source builds.

Trust model note: assets are still verified against the release `SHA256SUMS` (cosign-signed, see docs/verifying-releases.md) — the same model tag-pinned consumers already use. Consumers who want strictly pinned-source execution keep `prebuilt: never`.

Also bumps quickstart's stale `v0.2.0` action pins to `v0.3.0` and documents the source-build dep list.

## Verification

Executed the step body verbatim (extracted from action.yml) with `ACTION_REF=c7ef4fbb…` (the v0.3.0 commit):

```
Commit c7ef4fbb39f0054876ab2d286b3a6aaf86d05499 is release v0.3.0; using its prebuilt binaries.
bpfcompat-linux-amd64: OK
bpfcompat-validator-static-linux-amd64: OK
Using prebuilt release binaries for v0.3.0.
```

An unknown 40-hex SHA falls through to "building from source". `action.yml` YAML-parses (CI gate).

v0.3.1 candidate: once released, SHA-pinned consumers get prebuilt binaries on the next pin bump and the extra apt packages in consumer workflows become unnecessary.

🤖 Generated with [Claude Code](https://claude.com/claude-code)