### PR TITLE
fix(release): pin cosign CLI to v2.6.3; prepare v0.3.2

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -123,6 +123,15 @@ jobs:
       - name: Install cosign
         if: startsWith(github.ref, 'refs/tags/v')
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          # Pin the cosign CLI itself, not just the installer: without this
+          # the installer fetches latest cosign, and cosign v3 defaults to
+          # the new bundle format where --output-signature/--output-certificate
+          # are ignored ("create bundle file: open : no such file or
+          # directory" — broke the v0.3.1 tag build). Release assets and
+          # docs/verifying-releases.md use the .sig/.crt pair, so stay on
+          # cosign v2 until we migrate to bundles deliberately.
+          cosign-release: "v2.6.3"
       - name: Sign binary + SBOM (tag releases only)
         if: startsWith(github.ref, 'refs/tags/v')
         run: |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once a
 
 ## [Unreleased]
 
+## [0.3.2] - 2026-07-16
+
+### Fixed
+- **Release pipeline: pin the cosign CLI to v2.** The v0.3.1 tag build failed
+  at the signing step because the cosign installer fetched the new cosign v3,
+  which ignores `--output-signature`/`--output-certificate` in favor of the
+  bundle format. As a result **v0.3.1 has no release binaries** — it remains a
+  valid Go module version, but Action/tag consumers should use v0.3.2, which
+  is content-identical plus this pipeline fix.
+
 ## [0.3.1] - 2026-07-16
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ A complete, real example is [`examples/preload-gate`](examples/preload-gate):
 ![preload-gate.go — a real program using ValidateBeforeLoad](docs/images/library/library-code.png)
 
 ```sh
-go get github.com/kernel-guard/bpfcompat@v0.3.1
+go get github.com/kernel-guard/bpfcompat@v0.3.2
 go build -tags hostload -o preload-gate ./examples/preload-gate
 sudo ./preload-gate probe.bpf.o
 ```
@@ -315,7 +315,7 @@ guest-side validator binary and the kernel matrices that ship in this repo.
 the static validator, checksum-verified:
 
 ```bash
-VER=v0.3.1
+VER=v0.3.2
 base="https://github.com/Kernel-Guard/bpfcompat/releases/download/$VER"
 curl -fsSLO "$base/bpfcompat-linux-amd64"
 curl -fsSLO "$base/bpfcompat-validator-static-linux-amd64"
@@ -561,7 +561,7 @@ or the Firecracker lane. See
 Suite mode (recommended — gates the whole collection):
 
 ```yaml
-- uses: Kernel-Guard/bpfcompat@v0.3.1
+- uses: Kernel-Guard/bpfcompat@v0.3.2
   with:
     suite: suites/project.yaml
     suite-out: reports/suite.json
@@ -575,7 +575,7 @@ are alive and adds the result to the suite-level collection matrix.
 Single artifact:
 
 ```yaml
-- uses: Kernel-Guard/bpfcompat@v0.3.1
+- uses: Kernel-Guard/bpfcompat@v0.3.2
   with:
     artifact: path/to/program.bpf.o
     manifest: path/to/manifest.yaml
@@ -591,7 +591,7 @@ per-kernel verdict is the loader's exit code), against the built-in
 [library of known-tricky vendor kernels](docs/kernel-quirk-library.md):
 
 ```yaml
-- uses: Kernel-Guard/bpfcompat@v0.3.1
+- uses: Kernel-Guard/bpfcompat@v0.3.2
   with:
     command: $BPFCOMPAT_BIN --self-test
     command-binary: build/myloader   # static or fully self-contained binary

--- a/docs/case-study-falco-modern-bpf.md
+++ b/docs/case-study-falco-modern-bpf.md
@@ -67,7 +67,7 @@ keep in sync with the loader: the loader is the contract.
 
 ```bash
 # In CI (GitHub Action), against your kernel matrix:
-- uses: Kernel-Guard/bpfcompat@v0.3.1
+- uses: Kernel-Guard/bpfcompat@v0.3.2
   with:
     artifact: build/bpf_probe.o
     matrix: matrices/mvp.yaml

--- a/docs/command-validation.md
+++ b/docs/command-validation.md
@@ -109,7 +109,7 @@ on its own loader with one step. A bare `matrix` name resolves to the
 to copy:
 
 ```yaml
-- uses: Kernel-Guard/bpfcompat@v0.3.1
+- uses: Kernel-Guard/bpfcompat@v0.3.2
   with:
     command: $BPFCOMPAT_BIN --self-test
     command-binary: build/myloader

--- a/docs/ebpf-go-validation.md
+++ b/docs/ebpf-go-validation.md
@@ -50,7 +50,7 @@ Or in CI with the GitHub Action:
 
 ```yaml
 - run: cd examples/ebpf-go-loader && CGO_ENABLED=0 go build -o ebpf-go-loader .
-- uses: Kernel-Guard/bpfcompat@v0.3.1
+- uses: Kernel-Guard/bpfcompat@v0.3.2
   with:
     command: $BPFCOMPAT_BIN $BPFCOMPAT_ARTIFACT
     command-binary: examples/ebpf-go-loader/ebpf-go-loader

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -35,7 +35,7 @@ jobs:
     runs-on: ubuntu-latest          # exposes /dev/kvm for KVM acceleration
     steps:
       - uses: actions/checkout@v4
-      - uses: Kernel-Guard/bpfcompat@v0.3.1
+      - uses: Kernel-Guard/bpfcompat@v0.3.2
         with:
           artifact: build/program.bpf.o     # your compiled object
           matrix: matrices/mvp.yaml          # the kernels you support
@@ -57,7 +57,7 @@ What you get:
 Shipping a whole product? Use **suite mode** to gate a collection in one run:
 
 ```yaml
-      - uses: Kernel-Guard/bpfcompat@v0.3.1
+      - uses: Kernel-Guard/bpfcompat@v0.3.2
         with:
           suite: suites/project.yaml
           suite-out: reports/suite.json


### PR DESCRIPTION
The v0.3.1 tag build failed at signing: cosign-installer installs the latest cosign by default, and the actions-group dependabot bump moved runners onto **cosign v3**, which ignores `--output-signature`/`--output-certificate` (new bundle format) and errors with `create bundle file: open : no such file or directory`. [Failed run](https://github.com/Kernel-Guard/bpfcompat/actions/runs/29501697308).

- Pin `cosign-release: v2.6.3` on the installer (with a comment explaining why), keeping the `.sig`/`.crt` assets that docs/verifying-releases.md documents. Migrating to the v3 bundle format can be a deliberate follow-up.
- **v0.3.1 must not be retagged**: the Go module proxy already cached it (sumdb hash locked), so it stays as a valid module version with no release binaries. This PR prepares **v0.3.2** instead — content-identical plus the pipeline fix: changelog entry + `@v0.3.2` example bumps.

Tag v0.3.2 goes on the merge commit.

🤖 Generated with [Claude Code](https://claude.com/claude-code)