### PR TITLE
ci(freshness): file a tracking issue for stale baselines instead of failing

### DIFF
--- a/.github/workflows/kernel-freshness.yml
+++ b/.github/workflows/kernel-freshness.yml
@@ -2,10 +2,16 @@ name: kernel-freshness
 
 # Weekly freshness oracle for the image pipeline: compares the kernel each
 # profile last validated (vm/kernel-baselines.yaml) against the per-distro
-# kernel inventory published by falcosecurity/kernel-crawler. A red run means
-# at least one distro ships a kernel newer than the one our cached image
-# evidence covers — refresh the image and re-run the matrix, then update the
-# baselines with `bpfcompat kernel-freshness --update-from-report`.
+# kernel inventory published by falcosecurity/kernel-crawler.
+#
+# Staleness is a maintenance chore, not a failure: when profiles are behind,
+# the run stays green and files (or refreshes) a single tracking issue with
+# the current table; the issue closes itself once everything is fresh again.
+# A red run is reserved for the oracle itself breaking (crawler unreachable,
+# baseline file invalid), so red always means "investigate", never "chore
+# pending". To refresh a stale profile: re-fetch its image, re-run the
+# matrix, then update the baselines with
+# `bpfcompat kernel-freshness --update-from-report`.
 #
 # This is a non-blocking signal lane: nothing gates on it and it cannot
 # break merges. kernel-crawler refreshes its inventory weekly (Mondays), so
@@ -18,6 +24,7 @@ on:
 
 permissions:
   contents: read
+  issues: write   # file/refresh/close the stale-baselines tracking issue
 
 concurrency:
   group: ${{ github.workflow }}
@@ -43,8 +50,39 @@ jobs:
           ./bin/bpfcompat kernel-freshness \
             --baselines vm/kernel-baselines.yaml \
             --markdown freshness.md \
-            --json freshness.json \
-            --fail-on-stale
+            --json freshness.json
+
+      - name: File, refresh, or close the stale-baselines issue
+        env:
+          GH_TOKEN: ${{ github.token }}
+          RUN_URL: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+        run: |
+          title="Stale kernel baselines (weekly freshness report)"
+          stale="$(jq '[.[] | select(.status=="stale")] | length' freshness.json)"
+          num="$(gh issue list --state open --search "in:title \"$title\"" \
+            --json number,title --jq ".[] | select(.title == \"$title\") | .number" | head -1)"
+          if [[ "$stale" -eq 0 ]]; then
+            if [[ -n "$num" ]]; then
+              gh issue close "$num" --comment "All baselines fresh again as of $RUN_URL."
+            fi
+            echo "No stale baselines."
+            exit 0
+          fi
+          {
+            echo "The weekly freshness oracle found **$stale** profile(s) whose last-validated kernel is behind the newest shipping kernel in its series. Latest run: $RUN_URL"
+            echo
+            cat freshness.md
+            echo
+            echo "To refresh a profile: re-fetch its image, re-run the matrix, then update the baselines with \`bpfcompat kernel-freshness --update-from-report <report.json>\` (see docs/image-pipeline.md)."
+            echo
+            echo "_Filed and refreshed automatically by the kernel-freshness workflow; closes itself when all baselines are fresh._"
+          } > issue-body.md
+          if [[ -n "$num" ]]; then
+            gh issue edit "$num" --body-file issue-body.md
+            echo "Updated issue #$num ($stale stale)."
+          else
+            gh issue create --title "$title" --body-file issue-body.md
+          fi
 
       - name: Publish summary
         if: always()

--- a/docs/image-pipeline.md
+++ b/docs/image-pipeline.md
@@ -115,8 +115,11 @@ publishes weekly ([per-arch `list.json`](https://falcosecurity.github.io/kernel-
   show up as `uncovered` until one is added.
 - `.github/workflows/kernel-freshness.yml` runs the comparison weekly
   (after kernel-crawler's own Monday refresh) as a non-blocking signal
-  lane: a red run means "refresh the image, re-run the matrix, update the
-  baselines", never a blocked merge.
+  lane. Stale profiles keep the run green and file (or refresh) a single
+  "Stale kernel baselines" tracking issue that closes itself once
+  everything is fresh again; a red run is reserved for the oracle itself
+  breaking (crawler unreachable, invalid baselines file). Never a blocked
+  merge either way.
 - Statuses are honest about coverage limits: `uncovered` (kernel-crawler
   publishes no Debian entries, for example), `no-entries` (EOL series the
   archive dropped), and `no-kernel` (profile never validated) are reported


### PR DESCRIPTION
## What

The weekly `kernel-freshness` lane ran with `--fail-on-stale`, so any profile whose last-validated kernel is behind the newest shipping kernel turned the run **red**. Staleness is a routine maintenance chore (a distro shipped a newer kernel), not a regression — so the red carried no actionable signal and the lane had been failing, ignored, for weeks.

## Change

- Drop `--fail-on-stale` from the workflow. Staleness now keeps the run **green** and files (or refreshes) a single **"Stale kernel baselines"** tracking issue with the current table. The issue **closes itself** once every profile is fresh again.
- A **red** run is now reserved for the oracle itself breaking — crawler unreachable or an invalid baselines file, both of which still exit non-zero (verified locally). So red always means *investigate*, never *chore pending*.
- The issue-filing step has no `if: always()`, so a broken oracle stops the job before it can file a bogus issue.
- Docs (`docs/image-pipeline.md`) updated to match the new semantics.

## Verification

- `kernel-freshness` exit codes checked locally: stale-without-flag → 0; bad baselines file → 1; unreachable crawler → 1.
- jq stale-count logic and issue-body assembly tested against synthetic reports.
- Workflow YAML validated; CLI builds.

The `--fail-on-stale` flag stays in the CLI for local/manual use; only this lane stops using it.

Fixes the persistently-red weekly freshness lane.