### PR TITLE
chore(baselines): refresh stale kernel baselines via re-validation

### DIFF
--- a/vm/kernel-baselines.yaml
+++ b/vm/kernel-baselines.yaml
@@ -11,45 +11,45 @@ baselines:
     crawler:
       distro: almalinux
       target: almalinux
-      release_prefix: "6.12.0-"
+      release_prefix: 6.12.0-
       release_contains: el10
   - profile: almalinux-9-5.14
-    kernel: 5.14.0-611.54.6.el9_7.x86_64
-    recorded: "2026-05-19"
+    kernel: 5.14.0-687.5.3.el9_8.x86_64
+    recorded: "2026-07-20"
     crawler:
       distro: almalinux
       target: almalinux
-      release_prefix: "5.14.0-"
+      release_prefix: 5.14.0-
       release_contains: el9
   - profile: amazon-linux-2-5.10
-    kernel: 5.10.247-246.989.amzn2.x86_64
-    recorded: "2026-05-19"
+    kernel: 5.10.259-258.1046.amzn2.x86_64
+    recorded: "2026-07-20"
     crawler:
       distro: amazonlinux2
       target: amazonlinux2
-      release_prefix: "5.10."
+      release_prefix: 5.10.
   - profile: amazon-linux-2023-6.1
-    kernel: 6.1.170-213.321.amzn2023.x86_64
-    recorded: "2026-05-19"
+    kernel: 6.1.176-221.367.amzn2023.x86_64
+    recorded: "2026-07-20"
     crawler:
       distro: amazonlinux2023
       target: amazonlinux2023
-      release_prefix: "6.1."
+      release_prefix: 6.1.
   - profile: centos-stream-10-6.12
     kernel: 6.12.0-226.el10.x86_64
     recorded: "2026-05-19"
     crawler:
       distro: centos
       target: centos
-      release_prefix: "6.12.0-"
+      release_prefix: 6.12.0-
       release_contains: el10
   - profile: centos-stream-9-5.14
-    kernel: 5.14.0-706.el9.x86_64
-    recorded: "2026-05-19"
+    kernel: 5.14.0-722.el9.x86_64
+    recorded: "2026-07-20"
     crawler:
       distro: centos
       target: centos
-      release_prefix: "5.14.0-"
+      release_prefix: 5.14.0-
       release_contains: el9
   - profile: debian-11-5.10
     kernel: 5.10.0-42-cloud-amd64
@@ -69,14 +69,14 @@ baselines:
     crawler:
       distro: opensuse
       target: opensuse
-      release_prefix: "6.4.0-150600."
+      release_prefix: 6.4.0-150600.
   - profile: oracle-linux-10-uek8-6.12
     kernel: 6.12.0-107.59.3.3.el10uek.x86_64
     recorded: "2026-05-19"
     crawler:
       distro: ol
       target: ol
-      release_prefix: "6.12.0-"
+      release_prefix: 6.12.0-
       release_contains: el10uek
   - profile: oracle-linux-9-uek7-5.15
     kernel: 6.12.0-107.59.3.3.el9uek.x86_64
@@ -85,7 +85,7 @@ baselines:
     crawler:
       distro: ol
       target: ol
-      release_prefix: "6.12.0-"
+      release_prefix: 6.12.0-
       release_contains: el9uek
   - profile: rhel-8-4.18
     kernel: 5.15.0-206.153.7.1.el8uek.x86_64
@@ -94,7 +94,7 @@ baselines:
     crawler:
       distro: ol
       target: ol
-      release_prefix: "5.15.0-"
+      release_prefix: 5.15.0-
       release_contains: el8uek
   - profile: rocky-10-6.12
     kernel: 6.12.0-124.8.1.el10_1.x86_64
@@ -102,15 +102,15 @@ baselines:
     crawler:
       distro: rocky
       target: rocky
-      release_prefix: "6.12.0-"
+      release_prefix: 6.12.0-
       release_contains: el10
   - profile: rocky-9-5.14
-    kernel: 5.14.0-611.5.1.el9_7.x86_64
-    recorded: "2026-05-19"
+    kernel: 5.14.0-687.10.1.el9_8.0.1.x86_64
+    recorded: "2026-07-20"
     crawler:
       distro: rocky
       target: rocky
-      release_prefix: "5.14.0-"
+      release_prefix: 5.14.0-
       release_contains: el9
   - profile: sles-15.6-6.4
     kernel: 6.4.0-150600.23.100-default
@@ -119,109 +119,109 @@ baselines:
     crawler:
       distro: opensuse
       target: opensuse
-      release_prefix: "6.4.0-150600."
+      release_prefix: 6.4.0-150600.
   - profile: ubuntu-16.04-4.4
     kernel: 4.4.0-210-generic
     recorded: "2026-05-19"
     crawler:
       distro: ubuntu
       target: ubuntu-generic
-      release_prefix: "4.4.0-"
+      release_prefix: 4.4.0-
   - profile: ubuntu-18.04-4.15
     kernel: 4.15.0-212-generic
     recorded: "2026-05-22"
     crawler:
       distro: ubuntu
       target: ubuntu-generic
-      release_prefix: "4.15.0-"
+      release_prefix: 4.15.0-
   - profile: ubuntu-20.04-5.4
     kernel: 5.4.0-216-generic
     recorded: "2026-06-11"
     crawler:
       distro: ubuntu
       target: ubuntu-generic
-      release_prefix: "5.4.0-"
+      release_prefix: 5.4.0-
   - profile: ubuntu-20.04-minimal-5.4
     kernel: 5.4.0-1133-kvm
     recorded: "2026-05-19"
     crawler:
       distro: ubuntu
       target: ubuntu-kvm
-      release_prefix: "5.4.0-"
+      release_prefix: 5.4.0-
   - profile: ubuntu-20.10-5.8
     kernel: 5.8.0-63-generic
     recorded: "2026-05-19"
     crawler:
       distro: ubuntu
       target: ubuntu-generic
-      release_prefix: "5.8.0-"
+      release_prefix: 5.8.0-
   - profile: ubuntu-22.04-5.15
-    kernel: 5.15.0-173-generic
-    recorded: "2026-06-11"
+    kernel: 5.15.0-185-generic
+    recorded: "2026-07-20"
     crawler:
       distro: ubuntu
       target: ubuntu-generic
-      release_prefix: "5.15.0-"
+      release_prefix: 5.15.0-
   - profile: ubuntu-22.04-5.15-lockdown
-    kernel: 5.15.0-173-generic
-    recorded: "2026-05-19"
+    kernel: 5.15.0-185-generic
+    recorded: "2026-07-20"
     crawler:
       distro: ubuntu
       target: ubuntu-generic
-      release_prefix: "5.15.0-"
+      release_prefix: 5.15.0-
   - profile: ubuntu-22.04-minimal-5.15
-    kernel: 5.15.0-1098-kvm
-    recorded: "2026-05-22"
+    kernel: 5.15.0-1104-kvm
+    recorded: "2026-07-20"
     crawler:
       distro: ubuntu
       target: ubuntu-kvm
-      release_prefix: "5.15.0-"
+      release_prefix: 5.15.0-
   - profile: ubuntu-23.10-6.5
     kernel: 6.5.0-44-generic
     recorded: "2026-06-11"
     crawler:
       distro: ubuntu
       target: ubuntu-generic
-      release_prefix: "6.5.0-"
+      release_prefix: 6.5.0-
   - profile: ubuntu-24.04-6.8
-    kernel: 6.8.0-106-generic
-    recorded: "2026-06-11"
+    kernel: 6.8.0-134-generic
+    recorded: "2026-07-20"
     crawler:
       distro: ubuntu
       target: ubuntu-generic
-      release_prefix: "6.8.0-"
+      release_prefix: 6.8.0-
   - profile: ubuntu-24.04-minimal-6.8
-    kernel: 6.8.0-110-generic
-    recorded: "2026-05-19"
+    kernel: 6.8.0-136-generic
+    recorded: "2026-07-20"
     crawler:
       distro: ubuntu
       target: ubuntu-generic
-      release_prefix: "6.8.0-"
+      release_prefix: 6.8.0-
   - profile: ubuntu-24.10-6.11
     kernel: 6.11.0-29-generic
     recorded: "2026-06-03"
     crawler:
       distro: ubuntu
       target: ubuntu-generic
-      release_prefix: "6.11.0-"
+      release_prefix: 6.11.0-
   - profile: ubuntu-25.04-6.14
     kernel: 6.14.0-37-generic
     recorded: "2026-06-03"
     crawler:
       distro: ubuntu
       target: ubuntu-generic
-      release_prefix: "6.14.0-"
+      release_prefix: 6.14.0-
   - profile: ubuntu-25.10-6.17
     kernel: 6.17.0-22-generic
     recorded: "2026-06-03"
     crawler:
       distro: ubuntu
       target: ubuntu-generic
-      release_prefix: "6.17.0-"
+      release_prefix: 6.17.0-
   - profile: ubuntu-25.10-minimal-6.17
-    kernel: 6.17.0-23-generic
-    recorded: "2026-05-19"
+    kernel: 6.17.0-40-generic
+    recorded: "2026-07-20"
     crawler:
       distro: ubuntu
       target: ubuntu-generic
-      release_prefix: "6.17.0-"
+      release_prefix: 6.17.0-

--- a/vm/profiles/amazon-linux-2-5.10.yaml
+++ b/vm/profiles/amazon-linux-2-5.10.yaml
@@ -4,7 +4,7 @@ version: "2"
 kernel_family: "5.10"
 arch: x86_64
 image:
-  source_url: "https://cdn.amazonlinux.com/os-images/2.0.20260109.1/kvm/amzn2-kvm-2.0.20260109.1-x86_64.xfs.gpt.qcow2"
+  source_url: "https://cdn.amazonlinux.com/os-images/2.0.20260710.0/kvm/amzn2-kvm-2.0.20260710.0-x86_64.xfs.gpt.qcow2"
   local_path: "vm/cache/amazon-linux-2-5.10.qcow2"
 boot:
   memory_mb: 1024

--- a/vm/profiles/amazon-linux-2023-6.1.yaml
+++ b/vm/profiles/amazon-linux-2023-6.1.yaml
@@ -4,7 +4,7 @@ version: "2023"
 kernel_family: "6.1"
 arch: x86_64
 image:
-  source_url: "https://cdn.amazonlinux.com/al2023/os-images/2023.11.20260514.0/kvm/al2023-kvm-2023.11.20260514.0-kernel-6.1-x86_64.xfs.gpt.qcow2"
+  source_url: "https://cdn.amazonlinux.com/al2023/os-images/2023.12.20260720.0/kvm/al2023-kvm-2023.12.20260720.0-kernel-6.1-x86_64.xfs.gpt.qcow2"
   local_path: "vm/cache/amazon-linux-2023-6.1.qcow2"
 boot:
   memory_mb: 1024


### PR DESCRIPTION
## What

Refreshes the kernel baselines the weekly freshness oracle compares against. Re-fetched the current vendor cloud images, re-ran the matrix under KVM (real validator load + attach via `simple-pass`), and updated `vm/kernel-baselines.yaml` from the report — i.e. the baselines advance because the images were **actually re-validated**, not because version strings were hand-edited.

## Result

Freshness stale count **16 → 11**. 11 baselines advanced to the kernel the current image ships; 5 profiles are now fully fresh (amazon-linux-2, amazon-linux-2023, centos-stream-9, ubuntu-22.04-minimal, ubuntu-24.04-minimal).

Amazon profiles pin dated image builds, so their `source_url` is bumped to the newest builds (AL2 `2.0.20260710.0`, AL2023 `2023.12.20260720.0`); the other refreshed profiles track rolling image URLs.

## The 11 still flagged stale (and why they can't be closed by a base-image refresh)

**Inherent image-vs-package lag (6)** — refreshed, but the cloud image ships a kernel a point release behind the newest *package* kernel-crawler tracks. Closing this needs the in-guest kernel-sweep path (install the exact kernel in-guest), not a base-image swap: `almalinux-9`, `rocky-9`, `ubuntu-22.04` (+lockdown), `ubuntu-24.04`, `ubuntu-25.10-minimal`.

**Not refreshable by image swap (5):**
- `oracle-linux-9-uek7` — newer UEK kernel ships via in-guest `yum update`; OL9U8 base image not published.
- `rhel-8-4.18` — subscription-gated, profile has no `source_url` (operator-supplied image).
- `ubuntu-18.04`, `ubuntu-20.04` — ESM; `current` cloud image still ships the prior kernel.
- `ubuntu-25.10` (GA, non-minimal) — frozen release image; newer kernel is an `-updates` package.

## Verification

All 13 target VMs booted under KVM and passed validator load checks; kernels recorded from live `uname -r` inside each guest. With the new issue-filing freshness lane (#88), the tracking issue will auto-update to these 11 on its next run.