### PR TITLE
feat(freshness): family-aware coverage so sweep-validated kernels count

### DIFF
--- a/docs/image-pipeline.md
+++ b/docs/image-pipeline.md
@@ -124,6 +124,16 @@ publishes weekly ([per-arch `list.json`](https://falcosecurity.github.io/kernel-
   publishes no Debian entries, for example), `no-entries` (EOL series the
   archive dropped), and `no-kernel` (profile never validated) are reported
   distinctly from `stale`.
+- `covered` is the family-aware status. A stock cloud image can never ship
+  a kernel newer than itself, while the crawler tracks the newest *package*,
+  so an image-based profile would otherwise be flagged `stale` forever
+  through no fault of ours. When a
+  [kernel-sweep](#dense-kernel-sweeps-one-image-many-kernels)
+  profile in the same family (`<base>-k<release>`) has already installed and
+  validated the newest kernel, the base profile reports `covered` — naming
+  the profile that proves it — and is not counted as stale. Sibling variants
+  stay independent: `ubuntu-22.04-5.15-lockdown` is only covered by its own
+  `…-lockdown-k…` derivatives, never by plain `ubuntu-22.04-5.15` ones.
 
 The crawler indexes header packages, not bootable images, so it serves as
 a freshness oracle only — the boot substrate stays unmodified vendor cloud

--- a/internal/freshness/freshness.go
+++ b/internal/freshness/freshness.go
@@ -55,10 +55,18 @@ const DefaultArch = "x86_64"
 const (
 	StatusFresh     = "fresh"      // baseline >= newest shipping kernel in the series
 	StatusStale     = "stale"      // distro ships a newer kernel than last validated
+	StatusCovered   = "covered"    // this image lags, but a sweep profile validated the newest kernel
 	StatusUncovered = "uncovered"  // no crawler mapping for this profile
 	StatusNoEntries = "no-entries" // mapping matched nothing (typically an EOL series)
 	StatusNoKernel  = "no-kernel"  // baseline has a mapping but no recorded kernel yet
 )
+
+// derivedSeparator joins a base profile id to the kernel release a
+// kernel-sweep profile pins (ubuntu-22.04-5.15-k5.15.0-186). Matching on the
+// full "<base>-k" prefix keeps sibling profiles distinct: the lockdown
+// variant's derivatives start with "ubuntu-22.04-5.15-lockdown-k", so they
+// never register as derivatives of "ubuntu-22.04-5.15".
+const derivedSeparator = "-k"
 
 // Result is the freshness verdict for one baseline entry.
 type Result struct {
@@ -67,6 +75,9 @@ type Result struct {
 	Newest   string `json:"newest,omitempty"`
 	Status   string `json:"status"`
 	Reason   string `json:"reason,omitempty"`
+	// CoveredBy names the sweep profile that validated the newest kernel,
+	// set only when Status is StatusCovered.
+	CoveredBy string `json:"covered_by,omitempty"`
 }
 
 // Evaluate compares every baseline against the crawler inventory for its
@@ -108,11 +119,23 @@ func Evaluate(b Baselines, fetch func(arch string) (Inventory, error)) ([]Result
 				break
 			}
 			res.Newest = newest
-			if CompareKernelReleases(newest, entry.Kernel) > 0 {
+			switch {
+			case CompareKernelReleases(newest, entry.Kernel) <= 0:
+				res.Status = StatusFresh
+			default:
+				// The stock image lags the newest package, which is normal:
+				// vendors do not rebake cloud images for every point release.
+				// If a kernel-sweep profile in this family already installed
+				// and validated that kernel, the series is covered and there
+				// is nothing to act on.
+				if by, ok := familyCovers(b.Baselines, entry.Profile, newest); ok {
+					res.Status = StatusCovered
+					res.CoveredBy = by
+					res.Reason = "image lags, but " + by + " validated the newest kernel"
+					break
+				}
 				res.Status = StatusStale
 				res.Reason = "distro ships a newer kernel than the last validated image"
-			} else {
-				res.Status = StatusFresh
 			}
 		}
 		results = append(results, res)
@@ -120,11 +143,43 @@ func Evaluate(b Baselines, fetch func(arch string) (Inventory, error)) ([]Result
 	return results, nil
 }
 
-// StaleCount returns how many results are actionable.
+// familyCovers reports whether a kernel-sweep profile derived from base has
+// already validated a kernel at least as new as newest, and names the first
+// such profile. Derived ids are "<base>-k<release>"; the release must start
+// with a digit so unrelated ids that merely contain "-k" cannot match.
+func familyCovers(baselines []Baseline, base, newest string) (string, bool) {
+	prefix := base + derivedSeparator
+	best := ""
+	for _, candidate := range baselines {
+		if candidate.Kernel == "" || !strings.HasPrefix(candidate.Profile, prefix) {
+			continue
+		}
+		release := candidate.Profile[len(prefix):]
+		if release == "" || release[0] < '0' || release[0] > '9' {
+			continue
+		}
+		if CompareKernelReleases(candidate.Kernel, newest) < 0 {
+			continue
+		}
+		// Deterministic pick when several derivatives qualify.
+		if best == "" || candidate.Profile < best {
+			best = candidate.Profile
+		}
+	}
+	return best, best != ""
+}
+
+// StaleCount returns how many results are actionable. Covered profiles are
+// deliberately excluded: their series has been validated on the newest kernel
+// by a sweep profile, so there is no refresh to perform.
 func StaleCount(results []Result) int {
+	return countStatus(results, StatusStale)
+}
+
+func countStatus(results []Result, status string) int {
 	n := 0
 	for _, r := range results {
-		if r.Status == StatusStale {
+		if r.Status == status {
 			n++
 		}
 	}
@@ -227,6 +282,9 @@ func Markdown(results []Result) string {
 		b.WriteString("All covered profiles are validated against the newest kernel their distro ships.\n\n")
 	} else {
 		fmt.Fprintf(&b, "**%d profile(s) are behind what their distro currently ships.** Refresh the cached image and re-run the matrix to update evidence.\n\n", stale)
+	}
+	if covered := countStatus(results, StatusCovered); covered > 0 {
+		fmt.Fprintf(&b, "%d profile(s) are marked `covered`: the stock image lags the newest package, but a `kernel-sweep` profile in the same family already installed and validated that kernel, so there is nothing to refresh.\n\n", covered)
 	}
 	b.WriteString("| Profile | Last validated | Newest shipping | Status | Notes |\n")
 	b.WriteString("|---|---|---|---|---|\n")

--- a/internal/freshness/freshness_test.go
+++ b/internal/freshness/freshness_test.go
@@ -263,3 +263,54 @@ func TestUbuntuKernelDebs(t *testing.T) {
 		t.Error("expected error without flavor-specific headers URL")
 	}
 }
+
+func TestEvaluateFamilyCoverage(t *testing.T) {
+	fetch := func(string) (Inventory, error) {
+		return Inventory{"ubuntu": {
+			{KernelRelease: "5.15.0-184-generic", Target: "ubuntu-generic"},
+		}}, nil
+	}
+	jammyCrawler := func() *CrawlerRef {
+		return &CrawlerRef{Distro: "ubuntu", Target: "ubuntu-generic", ReleasePrefix: "5.15.0-"}
+	}
+	baselines := Baselines{Baselines: []Baseline{
+		// Stock image lags; a sweep profile validated the newest kernel.
+		{Profile: "ubuntu-22.04-5.15", Kernel: "5.15.0-173-generic", Crawler: jammyCrawler()},
+		{Profile: "ubuntu-22.04-5.15-k5.15.0-184", Kernel: "5.15.0-184-generic"},
+		// Sibling variant: the base profile's derivative must not cover it.
+		{Profile: "ubuntu-22.04-5.15-lockdown", Kernel: "5.15.0-173-generic", Crawler: jammyCrawler()},
+		// Derivative that only reached an older kernel does not cover.
+		{Profile: "ubuntu-22.04-minimal-5.15", Kernel: "5.15.0-173-generic", Crawler: jammyCrawler()},
+		{Profile: "ubuntu-22.04-minimal-5.15-k5.15.0-181", Kernel: "5.15.0-181-generic"},
+		// "-k" not followed by a digit is not a derived profile.
+		{Profile: "ubuntu-23.10-5.15", Kernel: "5.15.0-173-generic", Crawler: jammyCrawler()},
+		{Profile: "ubuntu-23.10-5.15-kvm-extra", Kernel: "5.15.0-184-generic"},
+	}}
+
+	results, err := Evaluate(baselines, fetch)
+	if err != nil {
+		t.Fatalf("Evaluate: %v", err)
+	}
+	got := map[string]Result{}
+	for _, r := range results {
+		got[r.Profile] = r
+	}
+
+	if s := got["ubuntu-22.04-5.15"]; s.Status != StatusCovered {
+		t.Errorf("base: status %q, want %q", s.Status, StatusCovered)
+	} else if s.CoveredBy != "ubuntu-22.04-5.15-k5.15.0-184" {
+		t.Errorf("base: covered_by %q", s.CoveredBy)
+	}
+	for _, profile := range []string{
+		"ubuntu-22.04-5.15-lockdown",
+		"ubuntu-22.04-minimal-5.15",
+		"ubuntu-23.10-5.15",
+	} {
+		if s := got[profile]; s.Status != StatusStale {
+			t.Errorf("%s: status %q, want %q", profile, s.Status, StatusStale)
+		}
+	}
+	if n := StaleCount(results); n != 3 {
+		t.Errorf("StaleCount = %d, want 3", n)
+	}
+}


### PR DESCRIPTION
Closes #92.

## Problem

A stock cloud image can never ship a kernel newer than itself, while kernel-crawler tracks the newest **package**. So image-based profiles were flagged `stale` permanently, no matter how much validation existed.

After #91 we literally had `ubuntu-22.04-5.15-k5.15.0-186` proving `5.15.0-186` loads and attaches on jammy — while `ubuntu-22.04-5.15` still reported `stale`. The oracle was asking *"did this exact profile boot the newest kernel?"* instead of the useful question, *"has the newest kernel for this series been validated at all?"*

## Change

Adds a `covered` status. When a kernel-sweep profile in the same family (`<base>-k<release>`) has validated a kernel at least as new as the newest shipping one, the base profile reports `covered`, names the profile that proves it (`covered_by`), and is excluded from `StaleCount`.

Family matching keys off the full `<base>-k` prefix **and requires a digit after it**, which gives two useful properties:
- **Sibling variants stay independent** — `ubuntu-22.04-5.15-lockdown` is only covered by its own `…-lockdown-k…` derivatives, never by plain `ubuntu-22.04-5.15` ones (verified in tests and on real data).
- Ids that merely contain `-k` (e.g. a `-kvm-…` suffix) cannot be mistaken for derivatives.

## Effect on the committed baselines

**Stale 11 → 6**, with 7 profiles correctly reattributed:

| Profile | covered_by |
|---|---|
| ubuntu-18.04-4.15 | …-k4.15.0-213 |
| ubuntu-20.04-5.4 | …-k5.4.0-218 |
| ubuntu-22.04-5.15 | …-k5.15.0-186 |
| ubuntu-22.04-5.15-lockdown | …-lockdown-k5.15.0-186 |
| ubuntu-24.04-6.8 | …-k6.8.0-136 |
| ubuntu-25.10-6.17 | …-k6.17.0-41 |
| ubuntu-25.10-minimal-6.17 | …-k6.17.0-41 |

The signal is not weakened — the remaining 6 are genuinely unvalidated on their newest kernel: `almalinux-9`, `rocky-9`, `centos-stream-9` (RHEL-family; kernel-sweep is Ubuntu-only), plus `oracle-linux-9-uek7` and `rhel-8` (not refreshable by image swap) and `amazon-linux-2` (which went newly stale mid-session — Amazon shipped `5.10.260` after we validated `5.10.259`, a good demonstration that the oracle still bites).

## Verification

New `TestEvaluateFamilyCoverage` covers: base covered by its derivative; sibling variant *not* covered by the base's derivative; a derivative that only reached an older kernel not covering; and the digit guard. Full suite, `gofmt`, and `golangci-lint` all clean. Docs updated in `docs/image-pipeline.md`; the weekly lane's Markdown report now explains the `covered` count.