### PR TITLE
examples: bpfman pre-load gate adapter

### DIFF
--- a/examples/bpfman-gate/gate.go
+++ b/examples/bpfman-gate/gate.go
@@ -1,0 +1,68 @@
+// Package bpfmangate adapts bpfcompat to bpfman's optional pre-load
+// validation hook.
+//
+// bpfman defines the interface; this supplies the implementation, so bpfman
+// itself never imports bpfcompat:
+//
+//	type PreLoadValidator interface {
+//	    ValidateBeforeLoad(ctx context.Context, objectPath string) error
+//	}
+//
+// Wire it up at construction:
+//
+//	mgr, err := manager.New(rt, puller, store, kern, progValidator, logger)
+//	if err != nil {
+//	    return err
+//	}
+//	mgr = mgr.WithPreLoadValidator(bpfmangate.New())
+//
+// Build with -tags hostload so bpfcompat validates against the running
+// kernel; without the tag it compiles to a stub that reports the feature is
+// unavailable rather than silently passing.
+package bpfmangate
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/kernel-guard/bpfcompat/pkg/bpfcompat"
+)
+
+// Gate refuses objects the running kernel's verifier will not accept.
+type Gate struct {
+	opts []bpfcompat.Option
+}
+
+// New returns a Gate. Options are passed through to bpfcompat, so a caller
+// can select load-only versus load-and-attach checking, point at an external
+// validator binary, and so on.
+func New(opts ...bpfcompat.Option) *Gate {
+	return &Gate{opts: opts}
+}
+
+// ValidateBeforeLoad implements bpfman's PreLoadValidator.
+//
+// The error is the product here: bpfman surfaces it to the caller verbatim,
+// so it carries the classification and the verifier's own reason instead of
+// the bare EINVAL the loader would otherwise produce.
+func (g *Gate) ValidateBeforeLoad(ctx context.Context, objectPath string) error {
+	res, err := bpfcompat.ValidateBeforeLoad(ctx, objectPath, g.opts...)
+	if err != nil {
+		// Infrastructure failure, not a verdict: the object was never
+		// judged, so say so rather than implying it was rejected.
+		return fmt.Errorf("pre-load check could not run: %w", err)
+	}
+	if res.OK() {
+		return nil
+	}
+
+	reason := res.Classification.Reason
+	if reason == "" {
+		reason = res.Load.LogTail
+	}
+	if reason == "" {
+		reason = "object rejected by the verifier"
+	}
+	return fmt.Errorf("%s on kernel %s (%s, errno %d)",
+		reason, res.Kernel.Release, res.Classification.Code, res.Load.Errno)
+}


### PR DESCRIPTION
Companion to a proposed hook in bpfman: [ErenAri/bpfman@preload-validation-gate](https://github.com/ErenAri/bpfman/tree/preload-validation-gate).

## Design

bpfman defines a tiny interface; we supply the implementation. **bpfman takes no dependency on bpfcompat** — that was the constraint worth designing around, since a hard dep would be an unreasonable ask of another project.

```go
// in bpfman
type PreLoadValidator interface {
    ValidateBeforeLoad(ctx context.Context, objectPath string) error
}

// in the consumer's wiring
mgr = mgr.WithPreLoadValidator(bpfmangate.New())
```

## Why the interface is shaped this way

It mirrors bpfman's existing `ProgramValidator` convention rather than inventing a new one. The two ask different questions: `ProgramValidator` is structural (*do these program names exist in this object*), this one is about the kernel (*will the verifier accept it here*). An object can name every program correctly and still be rejected for a missing helper, map type, or BTF relocation target.

**The error is the product.** bpfman surfaces it verbatim, so a refusal carries the classification code, the verifier's own reason, and the errno — instead of the bare `EINVAL` the loader produces today.

## Verified

- Builds with  and without (the no-tag stub reports the feature is unavailable rather than silently passing).
- On the bpfman side: their full `manager` suite passes with the patch, plus two new tests — a refusal blocks the load and leaves clean state, and the default nil validator is a no-op. (`platform/image/oci` fails there, but identically with my changes stashed — pre-existing.)