### PR TITLE
docs: integration templates for the remaining loader archetypes

### DIFF
--- a/README.md
+++ b/README.md
@@ -643,6 +643,7 @@ User guide — start here:
 
 Reference matrices (real, reproducible artifacts):
 
+- [`docs/integrations/`](docs/integrations/) — copy-paste templates: Go loader, Rust/Aya, OCI gadgets, and an in-process pre-load gate
 - [`docs/case-study-falco-modern-bpf.md`](docs/case-study-falco-modern-bpf.md) — Falco `modern_bpf` across 5 kernels
 - [`docs/case-study-enterprise-kernels.md`](docs/case-study-enterprise-kernels.md) — RHEL/Oracle/Amazon/SUSE backported tier
 - [`docs/case-study-inspektor-gadget.md`](docs/case-study-inspektor-gadget.md) — published gadgets from OCI, zero config

--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -1,0 +1,52 @@
+# Integration templates
+
+Copy-paste starting points for wiring bpfcompat into your project. Pick by how
+your project loads eBPF, not by what it does.
+
+| Your project | Template |
+|---|---|
+| Loads eBPF from **Go** (libbpfgo, ebpf-go/cilium) | [`go-loader-compatibility.yml`](go-loader-compatibility.yml) |
+| Loads eBPF from **Rust** (Aya) | [`rust-aya-compatibility.yml`](rust-aya-compatibility.yml) |
+| Publishes eBPF as **OCI artifacts** (Inspektor Gadget gadgets) | [`inspektor-gadget-compatibility.yml`](inspektor-gadget-compatibility.yml) |
+| Loads eBPF **at runtime** in a daemon or agent | [`library-gate.go.md`](library-gate.go.md) |
+| Loads eBPF from **C/libbpf** | Use the Go template and swap the build step; the contract is the binary, not the language. A live example is the [falcosecurity/libs lane](https://github.com/falcosecurity/libs/blob/master/.github/workflows/bpfcompat-compatibility.yml), which builds `scap-open` and runs it. |
+
+## The one idea behind all of them
+
+**Bring your own loader. There is nothing to maintain.**
+
+bpfcompat does not re-implement your load path or ask you to describe it in a
+manifest. It ships *your* binary into a VM running an unmodified vendor cloud
+image, runs it, and takes the exit code as the verdict for that kernel. There
+is no second description of your program to drift out of sync, because there is
+no second description.
+
+This matters more than it sounds. A libbpf load result does not transfer to
+ebpf-go or Aya — those are independent loaders that trail libbpf and can
+diverge on older kernels. The only result that is true for your users is the
+one produced by the loader you actually ship.
+
+## Why vendor kernels, not kernel versions
+
+The default `quirk-library` matrix boots real vendor images, because on
+enterprise kernels the version number stops predicting behaviour:
+
+- RHEL-family **4.18** backports the BPF ring buffer, so an object using it
+  passes there and fails on Ubuntu's *newer* vanilla **5.4**.
+- BPF-LSM is active in RHEL **9.4** but not **9.2** — the same 5.14 line.
+
+Test images built from upstream kernel versions structurally cannot show you
+either of those. Real vendor images can.
+
+## Pinning and supply chain
+
+Every template pins the action by commit SHA. A SHA that matches a release tag
+resolves to prebuilt, checksum-verified binaries, so your runner needs no
+toolchain; any other ref builds from source and needs `libbpf-dev` and
+`zlib1g-dev`. Releases are cosign-signed with SBOM and SLSA provenance.
+
+## Running it somewhere real
+
+The [falcosecurity/libs](https://github.com/falcosecurity/libs) lane runs this
+weekly against Falco's `modern_bpf` probe, driven by Falco's own loader
+([workflow](https://github.com/falcosecurity/libs/blob/master/.github/workflows/bpfcompat-compatibility.yml)).

--- a/docs/integrations/go-loader-compatibility.yml
+++ b/docs/integrations/go-loader-compatibility.yml
@@ -1,0 +1,84 @@
+# Template: kernel compatibility matrix for a Go eBPF loader.
+#
+# For projects that load eBPF from Go — libbpfgo (Tracee), ebpf-go/cilium
+# (Cilium, Beyla, Parca) or anything wrapping libbpf. Copy into
+# .github/workflows/.
+#
+# The contract is your own binary. bpfcompat builds nothing and parses no
+# manifest: it ships the loader you built into each guest, runs it, and takes
+# the exit code as the per-kernel verdict. Nothing to keep in sync, because
+# there is no second description of what your loader does.
+#
+# This is the shape running in falcosecurity/libs:
+# https://github.com/falcosecurity/libs/blob/master/.github/workflows/bpfcompat-compatibility.yml
+name: kernel-compatibility
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1" # weekly; a drift detector, not a merge gate
+
+permissions:
+  contents: read
+
+jobs:
+  kernel-matrix:
+    name: loader kernel compatibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: stable
+
+      - name: Install VM dependencies
+        run: |
+          sudo apt-get update
+          # cloud-image-utils supplies cloud-localds; RHEL-family guests only
+          # boot from a real cloud-init seed ISO.
+          sudo apt-get install -y --no-install-recommends \
+            qemu-system-x86 qemu-utils cloud-image-utils jq
+
+      - name: Enable KVM
+        run: if [[ -e /dev/kvm ]]; then sudo chmod 0666 /dev/kvm || true; fi
+
+      - name: Build the loader (static)
+        env:
+          CGO_ENABLED: "0" # cgo-free builds are static by default
+        run: |
+          set -euo pipefail
+          # Static matters: one binary runs unchanged on every guest, and the
+          # runner's glibc is newer than the RHEL-family guests'. With
+          # libbpfgo (cgo required) use instead:
+          #   CGO_ENABLED=1 go build -tags netgo \
+          #     -ldflags '-extldflags "-static"' -o bin/loader ./cmd/loader
+          go build -o bin/loader ./cmd/loader
+          file bin/loader
+
+      - name: Validate the loader across kernels
+        # Pinned by commit SHA. A SHA matching a release resolves to prebuilt,
+        # checksum-verified binaries, so no toolchain is needed for bpfcompat.
+        uses: Kernel-Guard/bpfcompat@48f7bf9bf0f19481c9dc98786c364358f8f0b902 # v0.3.2
+        with:
+          # $BPFCOMPAT_BIN is your binary inside the guest. Give it whatever
+          # flags make it load, do a bounded amount of work, and exit.
+          command: $BPFCOMPAT_BIN --self-test
+          command-binary: bin/loader
+          # Built-in matrix of vendor kernels where the version number stops
+          # predicting behaviour (RHEL 4.18 backports the ring buffer, so it
+          # passes where a newer vanilla 5.4 fails). Swap for your own file.
+          matrix: quirk-library
+          out: reports/kernel-compat.json
+          markdown: reports/kernel-compat.md
+          timeout: 15m
+          concurrency: "2"
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: kernel-compatibility-report
+          path: reports/
+          if-no-files-found: warn

--- a/docs/integrations/library-gate.go.md
+++ b/docs/integrations/library-gate.go.md
@@ -1,0 +1,80 @@
+# Template: embed the pre-load gate in a Go runtime or daemon
+
+For programs that load eBPF **at runtime on a machine you do not control** — a
+daemon, agent, or manager — rather than in CI. Instead of finding out from a
+bare `EINVAL` in production, ask before loading and fail with a reason.
+
+No VM is involved: this validates against the kernel the process is running on.
+
+## The interface
+
+Define it yourself so your project takes **no dependency** on bpfcompat:
+
+```go
+// PreLoadValidator answers whether an object can load on the running kernel.
+type PreLoadValidator interface {
+	ValidateBeforeLoad(ctx context.Context, objectPath string) error
+}
+```
+
+Keep the field optional and nil-by-default, so the check is opt-in and the
+zero value behaves exactly as before:
+
+```go
+type Manager struct {
+	// ...
+	preLoadValidator PreLoadValidator // optional; nil disables the check
+}
+
+func (m *Manager) WithPreLoadValidator(v PreLoadValidator) *Manager {
+	m.preLoadValidator = v
+	return m
+}
+```
+
+Call it once the object path is resolved and **before** taking any lock or
+touching the kernel, so a refusal costs nothing and leaves nothing behind:
+
+```go
+if m.preLoadValidator != nil {
+	if err := m.preLoadValidator.ValidateBeforeLoad(ctx, objectPath); err != nil {
+		return nil, fmt.Errorf("pre-load validation: %w", err)
+	}
+}
+```
+
+## The implementation
+
+```go
+import "github.com/kernel-guard/bpfcompat/pkg/bpfcompat"
+
+type gate struct{ opts []bpfcompat.Option }
+
+func (g *gate) ValidateBeforeLoad(ctx context.Context, objectPath string) error {
+	res, err := bpfcompat.ValidateBeforeLoad(ctx, objectPath, g.opts...)
+	if err != nil {
+		// Infrastructure failure, not a verdict: the object was never judged.
+		return fmt.Errorf("pre-load check could not run: %w", err)
+	}
+	if res.OK() {
+		return nil
+	}
+	return fmt.Errorf("%s on kernel %s (%s, errno %d)",
+		res.Classification.Reason, res.Kernel.Release,
+		res.Classification.Code, res.Load.Errno)
+}
+```
+
+Build with `-tags hostload`. Without the tag the package compiles to a stub
+that reports the feature is unavailable — deliberately, so a missing build tag
+can never look like "everything passed".
+
+## Why the error is the point
+
+Today a kernel-incompatible object comes back as a bare `EINVAL` with the real
+reason buried in the verifier log. The gate returns the classification code,
+the verifier's own reason, and the errno — before the load is attempted, so
+there is no half-loaded state to unwind.
+
+A worked example against a real project's tree (bpfman) lives in
+[`examples/bpfman-gate`](../../examples/bpfman-gate).

--- a/docs/integrations/rust-aya-compatibility.yml
+++ b/docs/integrations/rust-aya-compatibility.yml
@@ -1,0 +1,75 @@
+# Template: kernel compatibility matrix for a Rust/Aya eBPF loader.
+#
+# For projects loading eBPF from Rust with Aya. Copy into .github/workflows/.
+#
+# Aya matters here for a reason worth knowing: it is a pure-Rust loader, not a
+# libbpf wrapper. A "loads under libbpf" result therefore does not transfer —
+# Aya implements its own relocation and map-creation logic and can diverge on
+# older kernels. That is precisely why this validates *your* binary rather than
+# re-loading the object with libbpf: your loader is the contract.
+name: kernel-compatibility
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: "0 6 * * 1" # weekly; a drift detector, not a merge gate
+
+permissions:
+  contents: read
+
+jobs:
+  kernel-matrix:
+    name: loader kernel compatibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install Rust with a static target
+        run: |
+          set -euo pipefail
+          rustup toolchain install stable --profile minimal
+          # musl gives a fully static binary that runs on every guest,
+          # regardless of the guest's glibc.
+          rustup target add x86_64-unknown-linux-musl
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends musl-tools
+
+      - name: Install VM dependencies
+        run: |
+          sudo apt-get install -y --no-install-recommends \
+            qemu-system-x86 qemu-utils cloud-image-utils jq
+
+      - name: Enable KVM
+        run: if [[ -e /dev/kvm ]]; then sudo chmod 0666 /dev/kvm || true; fi
+
+      - name: Build the loader (static, musl)
+        run: |
+          set -euo pipefail
+          # Build the eBPF objects first if your project uses a separate
+          # bpf crate, e.g.:  cargo xtask build-ebpf --release
+          cargo build --release --target x86_64-unknown-linux-musl
+          file target/x86_64-unknown-linux-musl/release/loader
+
+      - name: Validate the loader across kernels
+        # Pinned by commit SHA; a SHA matching a release resolves to prebuilt,
+        # checksum-verified binaries.
+        uses: Kernel-Guard/bpfcompat@48f7bf9bf0f19481c9dc98786c364358f8f0b902 # v0.3.2
+        with:
+          # Exit 0 means Aya loaded and attached on this kernel; anything else
+          # is the verdict, with the guest's stderr captured in the report.
+          command: $BPFCOMPAT_BIN --self-test
+          command-binary: target/x86_64-unknown-linux-musl/release/loader
+          matrix: quirk-library
+          out: reports/kernel-compat.json
+          markdown: reports/kernel-compat.md
+          timeout: 15m
+          concurrency: "2"
+
+      - name: Upload report
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: kernel-compatibility-report
+          path: reports/
+          if-no-files-found: warn


### PR DESCRIPTION
Completes the template set. A maintainer can now copy one file rather than read a README and infer the rest — which is the difference between adoption that scales and adoption that needs six weeks of bespoke work per project.

| Archetype | Template |
|---|---|
| Go (libbpfgo, ebpf-go/cilium) | `go-loader-compatibility.yml` |
| Rust (Aya) | `rust-aya-compatibility.yml` |
| Runtime daemon/agent | `library-gate.go.md` |
| OCI gadget publisher | `inspektor-gadget-compatibility.yml` (existing) |
| C/libbpf | Covered by the Go template with a different build step — the contract is the binary, not the language |

## The framing

All four lead with the same idea, because it is the thing that actually unblocked the falcosecurity/libs merge: **bring your own loader, there is nothing to maintain.** No manifest means no second description of your program to drift out of sync.

The Rust template calls out something worth knowing: Aya is a pure-Rust loader, not a libbpf wrapper, so a "loads under libbpf" result does not transfer. Same for ebpf-go. That is the argument for validating the binary you actually ship rather than re-loading the object with someone else's loader.

## Details

- Every template pins by commit SHA, so a release-matching pin resolves to prebuilt, checksum-verified binaries and the consumer needs no toolchain.
- Static linking is called out in each build step with the reason (one binary must run unchanged on guests whose glibc is older than the runner's), including the cgo variant for libbpfgo.
- The library-gate doc keeps the interface *in the consumer's project*, so adopting it adds no dependency — the shape proven against bpfman's tree.
- All YAML validated; linked from the README docs index.
