### PR TITLE
docs: logo and prepared directory-listing assets

### DIFF
--- a/docs/assets/README.md
+++ b/docs/assets/README.md
@@ -1,0 +1,32 @@
+# Listing assets
+
+Prepared submissions for third-party directories. Kept here so a submission is
+a copy-paste, not a rewrite.
+
+## `bpfcompat-logo.svg`
+
+Mark-only (no text). Directory guidelines — CNCF landscape and ebpf.io both —
+reject font-rendered `<text>`, because it does not render identically on a
+machine without the font; the usual fix is converting text to outlines, so a
+mark with no text sidesteps it entirely. No embedded raster either.
+
+## `ebpf-io-entry.json`
+
+An entry for [ebpf.io](https://ebpf.io)'s project landscape, matching the shape
+in `src/data/pages/applications/emerging.json` of
+[`ebpf-io/ebpf.io-website`](https://github.com/ebpf-io/ebpf.io-website).
+
+Submitting also requires adding the logo to their asset pipeline and wiring
+`logoName` to it, so the PR touches more than the JSON. Ask in `#ebpf-website`
+on Cilium Slack first — their CONTRIBUTING covers blog posts only and says
+nothing about landscape entries, so the process is worth confirming rather than
+guessing.
+
+`githubStars` is a snapshot and needs refreshing at submission time.
+
+## Timing (read before submitting)
+
+Star count is low relative to the projects already listed. The stronger
+credential is not stars but that **falcosecurity/libs runs this weekly in CI** —
+lead with that. If a listing is declined, it is a timing problem, not a
+rejection of the work; re-submit once there are two or three named consumers.

--- a/docs/assets/bpfcompat-logo.svg
+++ b/docs/assets/bpfcompat-logo.svg
@@ -1,0 +1,18 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 256 256" role="img" aria-label="bpfcompat">
+  <title>bpfcompat</title>
+  <!-- Mark only, no text: listing guidelines (CNCF landscape, ebpf.io) reject
+       font-rendered text, which does not render identically off-machine.
+       Shield = the CI gate; the stacked bars = kernel profiles, the lowest one
+       broken = the incompatible kernel the gate catches. -->
+  <path fill="#1d4ed8"
+        d="M128 16 32 52v76c0 58 41 97 96 112 55-15 96-54 96-112V52L128 16z"/>
+  <path fill="#3b82f6"
+        d="M128 16v224c55-15 96-54 96-112V52L128 16z"/>
+  <g fill="#ffffff">
+    <rect x="74" y="96"  width="108" height="16" rx="8"/>
+    <rect x="74" y="128" width="108" height="16" rx="8"/>
+    <!-- broken bar: the kernel that fails -->
+    <rect x="74" y="160" width="42"  height="16" rx="8"/>
+    <rect x="140" y="160" width="42" height="16" rx="8"/>
+  </g>
+</svg>

--- a/docs/assets/ebpf-io-entry.json
+++ b/docs/assets/ebpf-io-entry.json
@@ -1,0 +1,12 @@
+{
+  "logoUrl": "https://github.com/Kernel-Guard/bpfcompat",
+  "name": "bpfcompat",
+  "logoName": "bpfcompatLogo",
+  "title": "eBPF kernel compatibility gate for CI",
+  "description": "bpfcompat proves a compiled eBPF object actually loads on the kernels you ship to, instead of assuming a version number predicts it. It boots unmodified vendor cloud images in disposable QEMU/KVM VMs and runs your own loader binary inside them, so the verdict comes from the loader you ship rather than a re-implementation — there is no manifest to drift out of sync. It reports per-kernel load/attach results with a classification for each failure, and surfaces cases where the version lies: RHEL-family 4.18 backports the BPF ring buffer and passes where a newer vanilla 5.4 fails, and BPF-LSM is live in RHEL 9.4 but not 9.2 on the same 5.14 line. It runs as a GitHub Action, a CLI, or a Go library for an in-process pre-load check, and can pull gadgets published as OCI artifacts.",
+  "urls": [
+    { "label": "GitHub", "url": "https://github.com/Kernel-Guard/bpfcompat" },
+    { "label": "Website", "url": "https://bpfcompat.kernelguard.net/" }
+  ],
+  "githubStars": 14
+}


### PR DESCRIPTION
Tier-5 listing work. Findings first, because two of the four items were not what I expected.

## Already done — GitHub Marketplace

The Action **is** listed: [marketplace/actions/bpfcompat-ebpf-compatibility-gate](https://github.com/marketplace/actions/bpfcompat-ebpf-compatibility-gate). My first check guessed the wrong slug and 404'd; the real slug derives from `action.yml`'s `name:`. No action needed.

## Blocker found — the project had no logo

Nothing SVG existed anywhere in the repo, and both ebpf.io and the CNCF landscape require one. Added `docs/assets/bpfcompat-logo.svg`:

- **Mark only, no `<text>`** — both guidelines reject font-rendered text (it doesn't render identically without the font; the standard fix is converting to outlines, which a text-free mark sidesteps).
- No embedded raster.
- Shield = the CI gate; stacked bars = kernel profiles, the bottom one broken = the incompatible kernel the gate catches.

It's serviceable, not a designed identity — worth replacing if this becomes a public-facing brand.

## Prepared, not submitted — ebpf.io

`docs/assets/ebpf-io-entry.json` matches the shape in their `emerging.json`. Not submitted yet, for two honest reasons:

1. The PR touches more than JSON — `logoName` has to be wired into their asset pipeline. Their CONTRIBUTING covers blog posts only and says nothing about landscape entries, so the process is worth confirming in `#ebpf-website` on Cilium Slack rather than guessing.
2. **14 stars**, against a list where Pyroscope shows 11,200. The stronger credential here isn't stars — it's that falcosecurity/libs runs this weekly in CI. Lead with that.

## Not attempted — CNCF landscape

Needs a Crunchbase organisation entry alongside the logo, which is a real prerequisite rather than a form field. Deferred rather than half-submitted.
