### PR TITLE
docs: OpenShift/RHCOS compatibility template for agent vendors

### DIFF
--- a/docs/integrations/README.md
+++ b/docs/integrations/README.md
@@ -9,6 +9,7 @@ your project loads eBPF, not by what it does.
 | Loads eBPF from **Rust** (Aya) | [`rust-aya-compatibility.yml`](rust-aya-compatibility.yml) |
 | Publishes eBPF as **OCI artifacts** (Inspektor Gadget gadgets) | [`inspektor-gadget-compatibility.yml`](inspektor-gadget-compatibility.yml) |
 | Loads eBPF **at runtime** in a daemon or agent | [`library-gate.go.md`](library-gate.go.md) |
+| Ships an agent to **OpenShift** customers | [`openshift-rhcos-compatibility.yml`](openshift-rhcos-compatibility.yml) |
 | Loads eBPF from **C/libbpf** | Use the Go template and swap the build step; the contract is the binary, not the language. A live example is the [falcosecurity/libs lane](https://github.com/falcosecurity/libs/blob/master/.github/workflows/bpfcompat-compatibility.yml), which builds `scap-open` and runs it. |
 
 ## The one idea behind all of them
@@ -33,7 +34,11 @@ enterprise kernels the version number stops predicting behaviour:
 
 - RHEL-family **4.18** backports the BPF ring buffer, so an object using it
   passes there and fails on Ubuntu's *newer* vanilla **5.4**.
-- BPF-LSM is active in RHEL **9.4** but not **9.2** — the same 5.14 line.
+- BPF-LSM is active in RHEL **9.4** but not **9.2** — the same 5.14 line. On
+  OpenShift that is the difference between OCP 4.16/4.18 and 4.14, and the
+  RHCOS version string encodes the RHEL base rather than the kernel
+  (`414.92` → RHEL 9.2, `416.94`/`418.94` → RHEL 9.4), so neither the OCP
+  number nor the kernel version tells you the answer.
 
 Test images built from upstream kernel versions structurally cannot show you
 either of those. Real vendor images can.

--- a/docs/integrations/openshift-rhcos-compatibility.yml
+++ b/docs/integrations/openshift-rhcos-compatibility.yml
@@ -1,0 +1,101 @@
+# Template: prove your eBPF agent loads on RHEL CoreOS (OpenShift nodes).
+#
+# For ISVs shipping an eBPF agent to OpenShift customers. Copy into
+# .github/workflows/.
+#
+# Why this is its own template: OpenShift nodes do not run a distro you can
+# approximate. RHCOS is immutable, boots via Ignition rather than cloud-init,
+# and carries a heavily backported RHEL kernel whose version number does not
+# tell you what eBPF features are present. Two findings from the committed
+# evidence make the point:
+#
+#   * BPF-LSM is active on OCP 4.16/4.18 (RHEL 9.4) and REJECTED on 4.14
+#     (RHEL 9.2) -- the same 5.14 kernel line, opposite answers.
+#   * The RHCOS version string encodes the RHEL base, not the kernel:
+#     414.92 -> RHEL 9.2, 416.94 and 418.94 -> RHEL 9.4.
+#
+# So "we tested on RHEL 9" is not evidence for OpenShift, and neither is a
+# kernel version. Booting the actual node image is.
+#
+# The boot images are PUBLIC: a pull secret gates the OpenShift release
+# payload, not the RHCOS qcow2. No subscription is needed for this workflow.
+name: openshift-node-compatibility
+
+on:
+  workflow_dispatch:
+  schedule:
+    # Monthly: OpenShift z-streams move the node image underneath you.
+    - cron: "0 6 1 * *"
+
+permissions:
+  contents: read
+
+jobs:
+  rhcos-matrix:
+    name: agent compatibility on RHCOS
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    strategy:
+      fail-fast: false
+      matrix:
+        # Track the OpenShift releases your customers actually run.
+        ocp: ["4.14", "4.16", "4.18"]
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Install VM dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            qemu-system-x86 qemu-utils cloud-image-utils jq
+
+      - name: Enable KVM
+        run: if [[ -e /dev/kvm ]]; then sudo chmod 0666 /dev/kvm || true; fi
+
+      - name: Build your agent (static)
+        run: |
+          set -euo pipefail
+          # One binary has to run unchanged inside the RHCOS guest, whose
+          # glibc is older than the runner's. Replace with your build.
+          make agent-static
+
+      - name: Stage the RHCOS boot image
+        env:
+          OCP: ${{ matrix.ocp }}
+        run: |
+          set -euo pipefail
+          # Public mirror; no pull secret. Pinning the exact z-stream is
+          # better than "latest" if you want reproducible evidence.
+          base="https://mirror.openshift.com/pub/openshift-v4/x86_64/dependencies/rhcos/${OCP}/latest"
+          url="$(curl -fsSL "$base/" \
+            | grep -oE 'rhcos-[0-9.]+-x86_64-qemu\.x86_64\.qcow2\.gz' \
+            | head -1)"
+          test -n "$url"
+          git clone --depth 1 https://github.com/Kernel-Guard/bpfcompat /tmp/bpfcompat
+          make -C /tmp/bpfcompat rhcos-image \
+            RHCOS_VERSION="${OCP}" RHCOS_IMAGE_URL="${base}/${url}"
+          mkdir -p vm/cache
+          cp /tmp/bpfcompat/vm/cache/rhcos-${OCP}.qcow2 vm/cache/
+
+      - name: Validate the agent on the OpenShift node OS
+        uses: Kernel-Guard/bpfcompat@48f7bf9bf0f19481c9dc98786c364358f8f0b902 # v0.3.2
+        env:
+          # RHCOS is opt-in: without a staged image it stays unsupported
+          # rather than being silently claimed runnable.
+          BPFCOMPAT_ENABLE_RHCOS: "1"
+        with:
+          command: $BPFCOMPAT_BIN --self-test
+          command-binary: bin/agent
+          matrix: rhcos
+          out: reports/openshift-${{ matrix.ocp }}.json
+          markdown: reports/openshift-${{ matrix.ocp }}.md
+          timeout: 25m
+          concurrency: "1"
+
+      - name: Upload evidence
+        if: always()
+        uses: actions/upload-artifact@v5
+        with:
+          name: openshift-${{ matrix.ocp }}-compatibility
+          path: reports/
+          if-no-files-found: warn


### PR DESCRIPTION
The RHCOS work so far is documented for an **operator** enabling the path (`rhcos-openshift.md`) and as **evidence** (`evidence-rhcos.md`). Neither speaks to the person who actually has the problem: an ISV shipping an eBPF agent to OpenShift customers.

This adds that template.

## Why OpenShift needs its own template rather than "use the RHEL profile"

OpenShift nodes cannot be approximated. RHCOS is immutable, boots via Ignition rather than cloud-init, and carries a backported RHEL kernel whose version number is not informative. Two findings from the committed evidence:

- A BPF-LSM program is **rejected on OCP 4.14 (RHEL 9.2)** and **loads and attaches on 4.16/4.18 (RHEL 9.4)** — the same 5.14 kernel line, opposite answers.
- The RHCOS version string encodes the **RHEL base, not the kernel**: `414.92` → RHEL 9.2, `416.94`/`418.94` → RHEL 9.4.

So "we tested on RHEL 9" is not evidence for OpenShift, and neither is `uname -r`. Booting the node image is.

## Practical note

The RHCOS **boot images are public** — the pull secret gates the OpenShift release payload, not the qcow2 — so this workflow needs no Red Hat subscription. That is what makes it usable in an ISV's own CI rather than only by an operator with entitlements.

Keeps the existing opt-in safety: `BPFCOMPAT_ENABLE_RHCOS` stays off by default, so RHCOS is never claimed runnable without a staged image.
