### PR TITLE
Harden production SSH execution and CodeQL gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,6 +73,8 @@ jobs:
         run: bash scripts/promote-release_test.sh
       - name: Production-environment protection regression
         run: bash scripts/check-production-environment_test.sh
+      - name: Production CodeQL alert-gate regression
+        run: bash scripts/check-production-code-scanning_test.sh
       - name: Production-readiness evidence regression
         run: bash scripts/production-readiness-report_test.sh
       - name: Release metadata consistency

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -56,3 +56,9 @@ jobs:
         uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
         with:
           category: "/language:go"
+
+      - name: Enforce zero open production-boundary alerts
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: bash scripts/check-production-code-scanning.sh "$GITHUB_REPOSITORY" "$GITHUB_REF"

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ LDFLAGS    ?= -X $(VERSION_PKG).Version=$(VERSION) \
               -X $(VERSION_PKG).BuildDate=$(BUILD_DATE)
 GO_BUILD_FLAGS ?= -trimpath -ldflags '$(LDFLAGS)'
 
-.PHONY: all deps vendor doctor doctor-virtme doctor-firecracker doctor-arm64-kvm firecracker-install firecracker-kernel-install firecracker-runnable firecracker-preflight arm64-kvm-preflight build test test-vendor tidy validator validator-dynamic validator-static pkg-embed-validator lib-hostload examples examples-arm64 oss-examples oss-evidence compatibility-site clean vm-ubuntu-22 vm-ubuntu-22-arm64 vm-image-fcos rhcos-image vm-images vm-images-tier1 vm-images-extended vm-images-expanded-2026 vm-images-expanded-2026-dry-run vm-images-latest-kernel matrix-runnable matrix-runnable-strict matrix-runnable-keep-manual latest-kernel-runnable upstream-kernel-runnable manual-image-check manual-image-check-strict profile-catalog-audit matrix-readiness support-matrix check-docs-drift check-release-consistency runtime-selector-proof runtime-delivery-proof production-runtime-drill beta-tech-check tech-stability production-tech-check production-readiness-report acceptance-dev-one acceptance-functional-dev-one acceptance-suite-dev-one acceptance-arm64-smoke acceptance-latest-kernel acceptance-upstream-kernel acceptance-firecracker-dev-one acceptance acceptance-expanded-runnable acceptance-evidence serve azure-provision-vm azure-bootstrap-vm azure-provision-foundation azure-production-boundary-proof azure-configure-tls azure-rotate-registry-secret
+.PHONY: all deps vendor doctor doctor-virtme doctor-firecracker doctor-arm64-kvm firecracker-install firecracker-kernel-install firecracker-runnable firecracker-preflight arm64-kvm-preflight build test test-vendor tidy validator validator-dynamic validator-static pkg-embed-validator lib-hostload examples examples-arm64 oss-examples oss-evidence compatibility-site clean vm-ubuntu-22 vm-ubuntu-22-arm64 vm-image-fcos rhcos-image vm-images vm-images-tier1 vm-images-extended vm-images-expanded-2026 vm-images-expanded-2026-dry-run vm-images-latest-kernel matrix-runnable matrix-runnable-strict matrix-runnable-keep-manual latest-kernel-runnable upstream-kernel-runnable manual-image-check manual-image-check-strict profile-catalog-audit matrix-readiness support-matrix check-docs-drift check-release-consistency check-production-code-scanning runtime-selector-proof runtime-delivery-proof production-runtime-drill beta-tech-check tech-stability production-tech-check production-readiness-report acceptance-dev-one acceptance-functional-dev-one acceptance-suite-dev-one acceptance-arm64-smoke acceptance-latest-kernel acceptance-upstream-kernel acceptance-firecracker-dev-one acceptance acceptance-expanded-runnable acceptance-evidence serve azure-provision-vm azure-bootstrap-vm azure-production-boundary-proof azure-configure-tls azure-rotate-registry-secret
 
 all: build validator
 
@@ -319,6 +319,9 @@ check-docs-drift:
 
 check-release-consistency:
 	bash scripts/check-release-consistency.sh
+
+check-production-code-scanning:
+	bash scripts/check-production-code-scanning.sh
 
 runtime-selector-proof: build
 	bash scripts/runtime-selector-proof.sh

--- a/docs/production-support-boundary.md
+++ b/docs/production-support-boundary.md
@@ -43,6 +43,13 @@ Required CI runs `gosec` through `golangci-lint` on production-boundary
 changes. A full-repository scan is retained as audit evidence, but it is not
 evidence that the excluded surfaces are production-ready.
 
+The CodeQL workflow also runs `scripts/check-production-code-scanning.sh`
+after analysis. It fails the required `Analyze (Go)` check when an open alert
+lands in a supported CLI, report, runner, or QEMU path. Firecracker and
+`virtme-ng` stay outside that path gate because they remain explicitly
+excluded; alerts in any excluded surface still require a recorded risk review
+and do not provide evidence that the surface is production-ready.
+
 ## Compatibility Claim
 
 A passing result means the recorded artifact or command loader completed the

--- a/internal/vm/ssh.go
+++ b/internal/vm/ssh.go
@@ -114,7 +114,7 @@ func sshProbe(ctx context.Context, target sshTarget) error {
 }
 
 func sshRun(ctx context.Context, target sshTarget, remoteCmd string) error {
-	cmd := exec.CommandContext(ctx, "ssh", target.sshArgs(remoteCmd)...)
+	cmd := sshScriptCommand(ctx, target, remoteCmd)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		msg := strings.TrimSpace(string(output))
@@ -127,7 +127,7 @@ func sshRun(ctx context.Context, target sshTarget, remoteCmd string) error {
 }
 
 func sshOutput(ctx context.Context, target sshTarget, remoteCmd string) (string, error) {
-	cmd := exec.CommandContext(ctx, "ssh", target.sshArgs(remoteCmd)...) // #nosec G204 -- remote commands are built from validated profile fields, same trust model as sshRun.
+	cmd := sshScriptCommand(ctx, target, remoteCmd)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
 		msg := strings.TrimSpace(string(output))
@@ -137,6 +137,17 @@ func sshOutput(ctx context.Context, target sshTarget, remoteCmd string) (string,
 		return "", fmt.Errorf("ssh run failed (%s): %s", target.addr(), msg)
 	}
 	return strings.TrimSpace(string(output)), nil
+}
+
+// sshScriptCommand keeps the local process invocation fixed and sends the
+// in-guest script over stdin. Command mode deliberately accepts arbitrary
+// loader shell from the caller, but that shell must never become part of the
+// host's ssh argv. OpenSSH runs the fixed "bash -s" command in the disposable
+// guest and forwards scriptInput on its standard input.
+func sshScriptCommand(ctx context.Context, target sshTarget, scriptInput string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, "ssh", target.sshArgs("bash -s")...)
+	cmd.Stdin = strings.NewReader(scriptInput)
+	return cmd
 }
 
 func scpToGuest(ctx context.Context, target sshTarget, localPath, remotePath string) error {

--- a/internal/vm/ssh.go
+++ b/internal/vm/ssh.go
@@ -34,6 +34,7 @@ func (t sshTarget) sshArgs(remoteCmd string) []string {
 		"-o", "UserKnownHostsFile=/dev/null",
 		"-o", "BatchMode=yes",
 		"-o", "ConnectTimeout=5",
+		"--",
 		t.addr(),
 		remoteCmd,
 	}
@@ -145,13 +146,16 @@ func sshOutput(ctx context.Context, target sshTarget, remoteCmd string) (string,
 // host's ssh argv. OpenSSH runs the fixed "bash -s" command in the disposable
 // guest and forwards scriptInput on its standard input.
 func sshScriptCommand(ctx context.Context, target sshTarget, scriptInput string) *exec.Cmd {
+	// #nosec G204 -- the executable and every option are fixed, target.sshArgs
+	// inserts "--" before the destination, and guest-controlled script content
+	// is carried only on stdin.
 	cmd := exec.CommandContext(ctx, "ssh", target.sshArgs("bash -s")...)
 	cmd.Stdin = strings.NewReader(scriptInput)
 	return cmd
 }
 
 func scpToGuest(ctx context.Context, target sshTarget, localPath, remotePath string) error {
-	args := append(target.scpBaseArgs(), localPath, fmt.Sprintf("%s:%s", target.addr(), remotePath))
+	args := append(target.scpBaseArgs(), "--", localPath, fmt.Sprintf("%s:%s", target.addr(), remotePath))
 	cmd := exec.CommandContext(ctx, "scp", args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {
@@ -165,7 +169,7 @@ func scpToGuest(ctx context.Context, target sshTarget, localPath, remotePath str
 }
 
 func scpFromGuest(ctx context.Context, target sshTarget, remotePath, localPath string) error {
-	args := append(target.scpBaseArgs(), fmt.Sprintf("%s:%s", target.addr(), remotePath), localPath)
+	args := append(target.scpBaseArgs(), "--", fmt.Sprintf("%s:%s", target.addr(), remotePath), localPath)
 	cmd := exec.CommandContext(ctx, "scp", args...)
 	output, err := cmd.CombinedOutput()
 	if err != nil {

--- a/internal/vm/ssh_test.go
+++ b/internal/vm/ssh_test.go
@@ -26,6 +26,13 @@ func TestSSHScriptCommandKeepsGuestScriptOutOfHostArgv(t *testing.T) {
 	if got := cmd.Args[len(cmd.Args)-1]; got != "bash -s" {
 		t.Fatalf("remote ssh command = %q, want fixed %q", got, "bash -s")
 	}
+	separator := slices.Index(cmd.Args, "--")
+	if separator < 0 || separator+2 >= len(cmd.Args) {
+		t.Fatalf("ssh argv must terminate options before destination and command: %#v", cmd.Args)
+	}
+	if got := cmd.Args[separator+2]; got != "bash -s" {
+		t.Fatalf("ssh command after option separator = %q, want %q", got, "bash -s")
+	}
 
 	stdin, err := io.ReadAll(cmd.Stdin)
 	if err != nil {

--- a/internal/vm/ssh_test.go
+++ b/internal/vm/ssh_test.go
@@ -1,0 +1,42 @@
+package vm
+
+import (
+	"context"
+	"io"
+	"slices"
+	"strings"
+	"testing"
+)
+
+func TestSSHScriptCommandKeepsGuestScriptOutOfHostArgv(t *testing.T) {
+	t.Parallel()
+
+	target := sshTarget{
+		User:       "tester",
+		PrivateKey: "/tmp/test-key",
+		Port:       2222,
+		Host:       "127.0.0.1",
+	}
+	scriptInput := "printf '%s\\n' 'guest payload; $(touch /host-must-not-run)'"
+
+	cmd := sshScriptCommand(context.Background(), target, scriptInput)
+	if slices.Contains(cmd.Args, scriptInput) {
+		t.Fatalf("guest script must not appear in host ssh argv: %#v", cmd.Args)
+	}
+	if got := cmd.Args[len(cmd.Args)-1]; got != "bash -s" {
+		t.Fatalf("remote ssh command = %q, want fixed %q", got, "bash -s")
+	}
+
+	stdin, err := io.ReadAll(cmd.Stdin)
+	if err != nil {
+		t.Fatalf("read command stdin: %v", err)
+	}
+	if got := string(stdin); got != scriptInput {
+		t.Fatalf("command stdin = %q, want %q", got, scriptInput)
+	}
+	for _, arg := range cmd.Args {
+		if strings.Contains(arg, "host-must-not-run") {
+			t.Fatalf("guest payload leaked into host argv argument %q", arg)
+		}
+	}
+}

--- a/scripts/check-production-code-scanning.sh
+++ b/scripts/check-production-code-scanning.sh
@@ -1,0 +1,86 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+REPOSITORY="${1:-${GITHUB_REPOSITORY:-}}"
+REF="${2:-${GITHUB_REF:-refs/heads/main}}"
+FIXTURE="${BPFCOMPAT_CODE_SCANNING_ALERTS_JSON:-}"
+
+if [[ -z "$REPOSITORY" ]]; then
+  echo "usage: $0 <owner/repository> [git-ref]" >&2
+  exit 2
+fi
+
+tmp_alerts="$(mktemp)"
+trap 'rm -f "$tmp_alerts"' EXIT
+
+if [[ -n "$FIXTURE" ]]; then
+  if [[ ! -f "$FIXTURE" ]]; then
+    echo "[production-code-scanning] fixture not found: $FIXTURE" >&2
+    exit 2
+  fi
+  python3 - "$FIXTURE" > "$tmp_alerts" <<'PY'
+import json
+import sys
+
+with open(sys.argv[1], encoding="utf-8") as handle:
+    alerts = json.load(handle)
+for alert in alerts:
+    instance = alert.get("most_recent_instance") or {}
+    location = instance.get("location") or {}
+    rule = alert.get("rule") or {}
+    fields = (
+        alert.get("number", ""),
+        rule.get("security_severity_level") or rule.get("severity") or "unknown",
+        rule.get("id", "unknown"),
+        location.get("path", ""),
+        alert.get("html_url", ""),
+    )
+    print("\t".join(str(field).replace("\t", " ") for field in fields))
+PY
+else
+  if ! command -v gh >/dev/null 2>&1; then
+    echo "[production-code-scanning] gh is required" >&2
+    exit 2
+  fi
+  gh api --method GET --paginate \
+    "repos/${REPOSITORY}/code-scanning/alerts" \
+    -f state=open \
+    -f ref="$REF" \
+    -f per_page=100 \
+    --jq '.[] | [.number, (.rule.security_severity_level // .rule.severity // "unknown"), .rule.id, (.most_recent_instance.location.path // ""), .html_url] | @tsv' \
+    > "$tmp_alerts"
+fi
+
+is_production_path() {
+  case "$1" in
+    internal/vm/firecracker.go|internal/vm/virtme_ng.go)
+      return 1
+      ;;
+    internal/artifact/*|internal/classifier/*|internal/compare/*|internal/envref/*|\
+    internal/freshness/*|internal/manifest/*|internal/matrix/*|internal/report/*|\
+    internal/runner/*|internal/safepath/*|internal/suite/*|internal/version/*|\
+    internal/vm/*|cmd/bpfcompat/main.go|cmd/bpfcompat/kernel_freshness.go|\
+    cmd/bpfcompat/kernel_sweep.go|cmd/bpfcompat/report_summary.go|cmd/bpfcompat/suite.go)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+failure_count=0
+while IFS=$'\t' read -r number severity rule path url; do
+  [[ -n "$number" ]] || continue
+  if is_production_path "$path"; then
+    echo "::error file=${path}::Open production-boundary code-scanning alert #${number} (${severity}, ${rule}): ${url}"
+    failure_count=$((failure_count + 1))
+  fi
+done < "$tmp_alerts"
+
+if (( failure_count > 0 )); then
+  echo "[production-code-scanning] FAIL: ${failure_count} open production-boundary alert(s) for ${REF}" >&2
+  exit 1
+fi
+
+echo "[production-code-scanning] PASS: no open production-boundary alerts for ${REF}"

--- a/scripts/check-production-code-scanning_test.sh
+++ b/scripts/check-production-code-scanning_test.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+tmp_dir="$(mktemp -d)"
+trap 'rm -rf "$tmp_dir"' EXIT
+
+fixture() {
+  local path="$1"
+  local number="$2"
+  cat > "$tmp_dir/alerts.json" <<JSON
+[
+  {
+    "number": ${number},
+    "html_url": "https://example.invalid/alerts/${number}",
+    "rule": {"id": "go/example", "security_severity_level": "high"},
+    "most_recent_instance": {"location": {"path": "${path}"}}
+  }
+]
+JSON
+}
+
+fixture "internal/api/server.go" 1
+BPFCOMPAT_CODE_SCANNING_ALERTS_JSON="$tmp_dir/alerts.json" \
+  bash scripts/check-production-code-scanning.sh Kernel-Guard/bpfcompat refs/heads/main
+
+fixture "internal/vm/virtme_ng.go" 2
+BPFCOMPAT_CODE_SCANNING_ALERTS_JSON="$tmp_dir/alerts.json" \
+  bash scripts/check-production-code-scanning.sh Kernel-Guard/bpfcompat refs/heads/main
+
+fixture "internal/vm/ssh.go" 3
+if BPFCOMPAT_CODE_SCANNING_ALERTS_JSON="$tmp_dir/alerts.json" \
+  bash scripts/check-production-code-scanning.sh Kernel-Guard/bpfcompat refs/heads/main; then
+  echo "expected supported VM alert to fail the gate" >&2
+  exit 1
+fi
+
+fixture "cmd/bpfcompat/main.go" 4
+if BPFCOMPAT_CODE_SCANNING_ALERTS_JSON="$tmp_dir/alerts.json" \
+  bash scripts/check-production-code-scanning.sh Kernel-Guard/bpfcompat refs/heads/main; then
+  echo "expected supported CLI entrypoint alert to fail the gate" >&2
+  exit 1
+fi
+
+echo "[production-code-scanning-test] PASS"


### PR DESCRIPTION
## What changed

- keep the host-side OpenSSH command line fixed and stream intentional guest shell over stdin
- add a regression test proving user guest script content never appears in the host `ssh` argv
- add a production-boundary code-scanning alert gate to the required CodeQL job
- add fixture-based gate regression coverage and document the security boundary

## Why

Main CodeQL alert #165 traced API-controlled command text into `internal/vm/ssh.go`. Command mode intentionally executes arbitrary loader shell inside a disposable QEMU guest, but that payload did not need to appear in the host OpenSSH argv. The new transport preserves guest behavior while making the host process invocation constant.

The existing CodeQL workflow uploaded findings but did not fail when a production-boundary alert remained open. The post-analysis gate now enforces zero open alerts in supported CLI/report/runner/QEMU paths. Experimental API, agent, runtime, Firecracker, and virtme-ng surfaces remain excluded and frozen.

## Validation

- `go test -race -count=1 ./internal/vm ./internal/runner ./internal/suite`
- `bash scripts/check-production-code-scanning_test.sh`
- YAML parse of `action.yml` and all workflows
- `actionlint v1.7.11`
- ShellCheck on both new scripts
- `make production-tech-check` (ready)
- `make acceptance-dev-one` (Ubuntu 22.04/5.15 QEMU/KVM pass)
