### PR TITLE
Prepare v0.4.0 release candidate quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,6 +77,8 @@ jobs:
         run: bash scripts/check-production-code-scanning_test.sh
       - name: Production-readiness evidence regression
         run: bash scripts/production-readiness-report_test.sh
+      - name: Coverage-floor regression
+        run: bash scripts/check-coverage_test.sh
       - name: Release metadata consistency
         run: make check-release-consistency
       - name: go vet
@@ -85,6 +87,8 @@ jobs:
         run: go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./...
       - name: Coverage summary
         run: go tool cover -func=coverage.out | tail -20
+      - name: Enforce coverage floor
+        run: bash scripts/check-coverage.sh coverage.out 50.0
       - name: Upload coverage artifact
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
         if: always()

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -69,11 +69,13 @@ jobs:
           bash scripts/check-release-state_test.sh
           bash scripts/check-release-consistency_test.sh
           bash scripts/check-production-environment_test.sh
+          bash scripts/check-coverage_test.sh
           bash scripts/promote-release_test.sh
           bash scripts/production-readiness-report_test.sh
           bash scripts/verify-release-assets_test.sh
           go vet ./...
-          go test -race -count=1 ./...
+          go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./...
+          bash scripts/check-coverage.sh coverage.out 50.0
           go run golang.org/x/vuln/cmd/govulncheck@v1.6.0 ./...
           make production-tech-check
       - name: Resolve build metadata

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once a
   GitHub-hosted KVM runner.
 - Container targets now default to CLI help instead of starting the frozen
   experimental API server.
+- Required CI and tagged releases now enforce a 50.0% total Go statement
+  coverage floor so coverage cannot silently regress during graduation.
 
 ### Security
 - Release downloads now require a release-workflow GitHub attestation or an
@@ -308,7 +310,7 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once a
   `load_attach` across the RHEL 8/9/10 ABI (AlmaLinux/Rocky/CentOS-Stream),
   Oracle UEK 7/8, Amazon Linux 2 (5.10 and the no-BTF 4.14) and 2023, and
   openSUSE Leap — documented in `docs/case-study-enterprise-kernels.md`.
-- **SLSA Build L3 build-provenance + SBOM attestations** on tag releases
+- **SLSA build provenance + SBOM attestations** on tag releases
   (keyless OIDC via Sigstore/Rekor), with a verification guide
   (`docs/verifying-releases.md`).
 - **Weekly stability gate** (`.github/workflows/stability-gate.yml`) producing an

--- a/docs/production-release-process.md
+++ b/docs/production-release-process.md
@@ -34,6 +34,9 @@ Before creating a release tag:
 3. `scripts/check-production-environment.sh` passes against the live GitHub
    configuration. The tag workflow runs this check before building release
    artifacts.
+4. Required CI and the tagged-release workflow enforce at least 50.0% total Go
+   statement coverage. Raise this floor as sustained coverage improvements
+   land; never lower it to make a release pass.
 
 ## Release Candidate
 

--- a/scripts/check-coverage.sh
+++ b/scripts/check-coverage.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+profile="${1:-coverage.out}"
+minimum="${2:-50.0}"
+
+fail() {
+  echo "[coverage] $*" >&2
+  exit 2
+}
+
+[[ -s "$profile" ]] || fail "coverage profile is missing or empty: ${profile}"
+[[ "$minimum" =~ ^[0-9]+([.][0-9]+)?$ ]] ||
+  fail "minimum must be a non-negative percentage"
+
+total="$(
+  go tool cover -func="$profile" |
+    awk '$1 == "total:" {gsub(/%/, "", $3); print $3; exit}'
+)"
+[[ "$total" =~ ^[0-9]+([.][0-9]+)?$ ]] ||
+  fail "could not read total statement coverage"
+
+if ! awk -v total="$total" -v minimum="$minimum" \
+  'BEGIN { exit !(total + 0 >= minimum + 0) }'; then
+  fail "total statement coverage ${total}% is below required ${minimum}%"
+fi
+
+echo "[coverage] PASS total=${total}% minimum=${minimum}%"

--- a/scripts/check-coverage_test.sh
+++ b/scripts/check-coverage_test.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+script="${ROOT_DIR}/scripts/check-coverage.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+mkdir -p "$tmp/bin"
+cat >"$tmp/bin/go" <<'EOF'
+#!/usr/bin/env bash
+set -euo pipefail
+if [[ "$*" != "tool cover -func="* ]]; then
+  exit 2
+fi
+printf 'total:\t(statements)\t%s%%\n' "$FIXTURE_COVERAGE"
+EOF
+chmod +x "$tmp/bin/go"
+printf 'mode: atomic\n' >"$tmp/coverage.out"
+
+PATH="$tmp/bin:$PATH" FIXTURE_COVERAGE=51.8 \
+  bash "$script" "$tmp/coverage.out" 50.0 >"$tmp/pass.log"
+grep -Fq '[coverage] PASS total=51.8% minimum=50.0%' "$tmp/pass.log"
+
+if PATH="$tmp/bin:$PATH" FIXTURE_COVERAGE=49.9 \
+  bash "$script" "$tmp/coverage.out" 50.0 >"$tmp/fail.log" 2>&1; then
+  echo "[coverage-test] accepted coverage below the floor" >&2
+  exit 1
+fi
+grep -Fq 'below required 50.0%' "$tmp/fail.log"
+
+if PATH="$tmp/bin:$PATH" FIXTURE_COVERAGE=invalid \
+  bash "$script" "$tmp/coverage.out" 50.0 >/dev/null 2>&1; then
+  echo "[coverage-test] accepted invalid coverage output" >&2
+  exit 1
+fi
+
+if PATH="$tmp/bin:$PATH" FIXTURE_COVERAGE=51.8 \
+  bash "$script" "$tmp/coverage.out" invalid >/dev/null 2>&1; then
+  echo "[coverage-test] accepted an invalid minimum" >&2
+  exit 1
+fi
+
+echo "[coverage-test] PASS"


### PR DESCRIPTION
## What changed

- enforce a 50.0% total Go statement-coverage floor in required CI and the tagged-release workflow
- add regression coverage for the coverage parser and fail-closed behavior
- document the ratchet policy in the production release process
- correct the historical `SLSA Build L3` wording to the accurate `SLSA build provenance` claim

## Why

The v0.4.0 production-graduation track needs an objective coverage floor and accurate supply-chain claims before the release candidate is tagged. Current total statement coverage is 51.8%, so the 50.0% floor prevents regressions while leaving a small margin for platform-dependent instrumentation.

This is a release-quality and documentation-only change. It does not expand the production support boundary or count the manual KVM shakeout as graduation evidence.

## Validation

- `bash scripts/check-coverage_test.sh`
- `go test -race -count=1 -coverprofile=coverage.out -covermode=atomic ./...`
- `bash scripts/check-coverage.sh coverage.out 50.0` (`51.8%`)
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.11`
- `make check-release-consistency`
- `make check-docs-drift`
- `git diff --check`

The exact pre-change `main` commit also passed the full release-quality and production-tech suite. Hosted-KVM shakeout run 30492156638 passed 4/4 targets with zero infrastructure errors; it remains non-counting because its event was `workflow_dispatch`.
