### PR TITLE
Fix tag release quality gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once a
 
 ## [Unreleased]
 
+## [0.4.0-rc.2] - 2026-07-30
+
+### Fixed
+- Isolated release-consistency fixtures from the tag workflow environment so
+  candidate tags do not make stable-metadata regression fixtures fail.
+- Removed the release-consistency checker's undeclared `ripgrep` dependency;
+  tag release jobs now use the baseline `grep` tool available on hosted
+  runners.
+
 ## [0.4.0-rc.1] - 2026-07-29
 
 ### Added

--- a/release.yaml
+++ b/release.yaml
@@ -1,5 +1,5 @@
 stable_version: 0.3.6
-release_version: 0.4.0-rc.1
+release_version: 0.4.0-rc.2
 release_channel: prerelease
 release_reviewer: yusuf-demirel4
 minimum_go: 1.25.12

--- a/scripts/check-release-consistency.sh
+++ b/scripts/check-release-consistency.sh
@@ -91,7 +91,7 @@ for required_control in \
 done
 
 unexpected_release_writers="$(
-  rg -l --glob '*.yml' --glob '*.yaml' \
+  grep -ERl --include='*.yml' --include='*.yaml' \
     'gh release (create|upload|edit)|softprops/action-gh-release@' .github/workflows |
     grep -vFx "$release_workflow" || true
 )"
@@ -101,7 +101,7 @@ if [[ -n "$unexpected_release_writers" ]]; then
 fi
 
 unexpected_latest_writers="$(
-  rg -l --glob '*.yml' --glob '*.yaml' \
+  grep -ERl --include='*.yml' --include='*.yaml' \
     -- '--tag .*IMAGE.*:latest|value=latest' .github/workflows |
     grep -vFx "$release_workflow" || true
 )"
@@ -111,8 +111,8 @@ if [[ -n "$unexpected_latest_writers" ]]; then
 fi
 
 bad_action_refs="$(
-  rg -n 'uses: Kernel-Guard/bpfcompat@v[0-9]+\.[0-9]+\.[0-9]+' \
-    README.md docs --glob '*.md' --glob '*.yml' --glob '*.yaml' |
+  grep -ERn --include='*.md' --include='*.yml' --include='*.yaml' \
+    'uses: Kernel-Guard/bpfcompat@v[0-9]+\.[0-9]+\.[0-9]+' README.md docs |
     grep -vF "@${stable_action_tag}" || true
 )"
 if [[ -n "$bad_action_refs" ]]; then
@@ -123,7 +123,10 @@ fi
 while IFS= read -r workflow; do
   grep -Fq "GO_VERSION: \"${minimum_go}\"" "$workflow" ||
     fail "$workflow does not use Go ${minimum_go}"
-done < <(rg -l '^  GO_VERSION: ' .github/workflows --glob '*.yml' --glob '*.yaml')
+done < <(
+  grep -ERl --include='*.yml' --include='*.yaml' \
+    '^  GO_VERSION: ' .github/workflows
+)
 
 if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
   [[ "${GITHUB_REF_NAME:-}" == "$release_tag" ]] ||

--- a/scripts/check-release-consistency_test.sh
+++ b/scripts/check-release-consistency_test.sh
@@ -4,9 +4,16 @@ set -euo pipefail
 ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 cd "$ROOT_DIR"
 
+# A tag workflow exports these variables to every child process. Individual
+# fixtures below set them only when tag matching is the behavior under test.
+unset GITHUB_REF_TYPE GITHUB_REF_NAME
+
 script="scripts/check-release-consistency.sh"
 tmp="$(mktemp -d)"
 trap 'rm -rf "$tmp"' EXIT
+current_release="$(
+  awk -F': ' '$1 == "release_version" {print $2; exit}' release.yaml
+)"
 
 write_metadata() {
   local stable="$1"
@@ -30,7 +37,7 @@ write_metadata 0.3.6 0.3.6 stable
 BPFCOMPAT_RELEASE_METADATA="$tmp/release.yaml" "$script" >"$tmp/stable.log"
 grep -Fq 'channel=stable' "$tmp/stable.log"
 
-GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v0.4.0-rc.1 \
+GITHUB_REF_TYPE=tag GITHUB_REF_NAME="v${current_release}" \
   BPFCOMPAT_RELEASE_METADATA=release.yaml "$script" >"$tmp/tag.log"
 
 for bad_case in \
@@ -48,7 +55,7 @@ for bad_case in \
   fi
 done
 
-if GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v0.4.0-rc.2 \
+if GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v9.9.9 \
   BPFCOMPAT_RELEASE_METADATA=release.yaml \
   "$script" >"$tmp/bad-tag.log" 2>&1; then
   echo "[release-consistency-test] accepted mismatched release tag" >&2


### PR DESCRIPTION
## Root cause

The `v0.4.0-rc.1` tag workflow failed in `Release quality gates` before any artifact build, draft release, image promotion, or environment approval:

1. `check-release-consistency_test.sh` inherited `GITHUB_REF_TYPE=tag` and `GITHUB_REF_NAME=v0.4.0-rc.1` from Actions. Its stable-metadata fixture was therefore incorrectly validated against the live RC tag.
2. `check-release-consistency.sh` used `rg`, which is not installed in the release job. The affected pipelines masked the missing command with `|| true`, making those checks fail open.

## Fix

- isolate regression fixtures from inherited tag variables and set them only in tag-specific cases
- derive the positive tag fixture from `release.yaml`
- replace the undeclared `rg` calls with baseline recursive `grep`
- advance the immutable candidate identifier to `v0.4.0-rc.2`; the failed `rc.1` tag is not moved or reused

## Impact

No `v0.4.0-rc.1` release, release asset, GHCR version tag, moving alias, or production deployment was published. The protected-environment configuration check passed before the quality gate failed.

## Validation

- `GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v0.4.0-rc.2 bash scripts/check-release-consistency_test.sh`
- `GITHUB_REF_TYPE=tag GITHUB_REF_NAME=v0.4.0-rc.2 bash scripts/check-release-consistency.sh`
- `bash scripts/check-coverage_test.sh`
- `make check-docs-drift`
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.11`
- `shellcheck scripts/check-release-consistency.sh scripts/check-release-consistency_test.sh`
- `git diff --check`

Failed run: https://github.com/Kernel-Guard/bpfcompat/actions/runs/30492851666
