### PR TITLE
Add solo release promotion gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,6 +71,8 @@ jobs:
         run: bash scripts/check-release-consistency_test.sh
       - name: Release-channel promotion regression
         run: bash scripts/promote-release_test.sh
+      - name: Candidate-promotion binding regression
+        run: bash scripts/verify-promotion-inputs_test.sh
       - name: Production-environment protection regression
         run: bash scripts/check-production-environment_test.sh
       - name: Production CodeQL alert-gate regression

--- a/.github/workflows/promote-release.yml
+++ b/.github/workflows/promote-release.yml
@@ -1,0 +1,249 @@
+name: promote-release
+
+# Deliberate solo-maintainer publication gate. The tag workflow can only stage
+# a private draft. Promotion requires a separate dispatch on that exact tag with
+# the exact candidate run, commit, and image digest copied from attested
+# evidence. The production environment adds a 15-minute cooling-off period.
+
+on:
+  workflow_dispatch:
+    inputs:
+      release_tag:
+        description: Immutable vX.Y.Z or vX.Y.Z-rc.N tag to publish.
+        required: true
+        type: string
+      candidate_run_id:
+        description: Successful release-artifacts candidate workflow run ID.
+        required: true
+        type: string
+      expected_commit:
+        description: Full 40-character commit SHA bound to the tag.
+        required: true
+        type: string
+      expected_image_digest:
+        description: Exact sha256 image digest from candidate evidence.
+        required: true
+        type: string
+      confirmation:
+        description: Type promote followed by a space and the exact release tag.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-release-promotion
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/kernel-guard/bpfcompat
+
+jobs:
+  promote:
+    name: Promote image and publish release
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment:
+      name: production-release
+    permissions:
+      actions: read
+      attestations: read
+      contents: write
+      packages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          fetch-depth: 0
+
+      - name: Manual promotion confirmation
+        env:
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          CANDIDATE_RUN_ID: ${{ inputs.candidate_run_id }}
+          EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+          EXPECTED_DIGEST: ${{ inputs.expected_image_digest }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = "refs/tags/${RELEASE_TAG}"
+          [[ "$CANDIDATE_RUN_ID" =~ ^[1-9][0-9]*$ ]]
+          [[ "$EXPECTED_COMMIT" =~ ^[0-9a-f]{40}$ ]]
+          [[ "$EXPECTED_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
+          test "$CONFIRMATION" = "promote ${RELEASE_TAG}"
+
+          metadata_tag="v$(awk -F': ' '$1 == "release_version" {print $2; exit}' release.yaml)"
+          test "$RELEASE_TAG" = "$metadata_tag"
+          actual_commit="$(git rev-parse "refs/tags/${RELEASE_TAG}^{commit}")"
+          test "$actual_commit" = "$EXPECTED_COMMIT"
+
+      - name: Verify solo production environment
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          approval_mode="$(awk -F': ' '$1 == "approval_mode" {print $2; exit}' release.yaml)"
+          bash scripts/check-production-environment.sh \
+            "$GITHUB_REPOSITORY" production-release "$approval_mode"
+
+      - name: Verify candidate workflow identity
+        id: candidate
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDIDATE_RUN_ID: ${{ inputs.candidate_run_id }}
+          EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          run_json="$(gh api "repos/${GITHUB_REPOSITORY}/actions/runs/${CANDIDATE_RUN_ID}")"
+          jq -e \
+            --arg commit "$EXPECTED_COMMIT" \
+            --arg tag "$RELEASE_TAG" '
+              .path == ".github/workflows/release-artifacts.yml" and
+              .event == "push" and
+              .status == "completed" and
+              .conclusion == "success" and
+              .head_sha == $commit and
+              .head_branch == $tag and
+              (.run_attempt | type == "number" and . > 0)
+            ' <<<"$run_json" >/dev/null
+          echo "run_attempt=$(jq -r .run_attempt <<<"$run_json")" >>"$GITHUB_OUTPUT"
+
+      - name: Download exact candidate artifacts
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDIDATE_RUN_ID: ${{ inputs.candidate_run_id }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          gh run download "$CANDIDATE_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name "bpfcompat-release-${RELEASE_TAG}" \
+            --dir candidate/run-assets
+          gh run download "$CANDIDATE_RUN_ID" \
+            --repo "$GITHUB_REPOSITORY" \
+            --name "bpfcompat-candidate-evidence-${RELEASE_TAG}" \
+            --dir candidate/run-evidence
+          gh release download "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --dir candidate/draft-assets
+
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: "v2.6.3"
+
+      - name: Re-verify evidence, draft assets, signatures, and channel
+        env:
+          GH_TOKEN: ${{ github.token }}
+          CANDIDATE_RUN_ID: ${{ inputs.candidate_run_id }}
+          CANDIDATE_RUN_ATTEMPT: ${{ steps.candidate.outputs.run_attempt }}
+          EXPECTED_COMMIT: ${{ inputs.expected_commit }}
+          EXPECTED_DIGEST: ${{ inputs.expected_image_digest }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          channel="$(awk -F': ' '$1 == "release_channel" {print $2; exit}' release.yaml)"
+          evidence="candidate/run-evidence/release-candidate-evidence.json"
+          bash scripts/verify-promotion-inputs.sh \
+            "$evidence" "$GITHUB_REPOSITORY" "$RELEASE_TAG" \
+            "$CANDIDATE_RUN_ID" "$CANDIDATE_RUN_ATTEMPT" \
+            "$EXPECTED_COMMIT" "$EXPECTED_DIGEST" "$channel" \
+            candidate/run-assets/SHA256SUMS
+
+          cmp candidate/run-assets/SHA256SUMS candidate/draft-assets/SHA256SUMS
+          cmp "$evidence" candidate/draft-assets/release-candidate-evidence.json
+
+          assets=(
+            bpfcompat-linux-amd64
+            bpfcompat-linux-arm64
+            bpfcompat-validator-static-linux-amd64
+          )
+          if [[ "$channel" == "stable" ]]; then
+            assets+=(production-readiness.json production-readiness.md)
+          fi
+          bash scripts/verify-release-assets.sh \
+            candidate/draft-assets "$GITHUB_REPOSITORY" "${assets[@]}"
+          gh attestation verify "$evidence" \
+            --repo "$GITHUB_REPOSITORY" \
+            --signer-workflow "${GITHUB_REPOSITORY}/.github/workflows/release-artifacts.yml"
+
+          identity_regexp="^https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release-artifacts.yml@refs/tags/v"
+          cosign verify-blob \
+            --certificate candidate/draft-assets/SHA256SUMS.crt \
+            --signature candidate/draft-assets/SHA256SUMS.sig \
+            --certificate-identity-regexp "$identity_regexp" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            candidate/draft-assets/SHA256SUMS
+          cosign verify-blob \
+            --certificate candidate/draft-assets/bpfcompat.sbom.cdx.crt \
+            --signature candidate/draft-assets/bpfcompat.sbom.cdx.sig \
+            --certificate-identity-regexp "$identity_regexp" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            candidate/draft-assets/bpfcompat.sbom.cdx.json
+
+          release_json="$(gh release view "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json tagName,isDraft,isPrerelease)"
+          jq -e \
+            --arg tag "$RELEASE_TAG" \
+            --arg channel "$channel" '
+              .tagName == $tag and
+              .isDraft == true and
+              .isPrerelease == ($channel == "prerelease")
+            ' <<<"$release_json" >/dev/null
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Verify candidate image immediately before promotion
+        env:
+          EXPECTED_DIGEST: ${{ inputs.expected_image_digest }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          expected_version="$RELEASE_TAG"
+          actual_version="$(docker run --rm "${IMAGE}@${EXPECTED_DIGEST}" \
+            version --json | jq -r .version)"
+          test "$actual_version" = "$expected_version"
+          cosign verify \
+            --certificate-identity-regexp "^https://github.com/${GITHUB_REPOSITORY}/.github/workflows/release-artifacts.yml@refs/tags/v" \
+            --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+            "${IMAGE}@${EXPECTED_DIGEST}"
+
+      - name: Promote the verified image digest
+        env:
+          EXPECTED_DIGEST: ${{ inputs.expected_image_digest }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          channel="$(awk -F': ' '$1 == "release_channel" {print $2; exit}' release.yaml)"
+          bash scripts/promote-release.sh \
+            "$IMAGE" "$EXPECTED_DIGEST" "$RELEASE_TAG" "$channel"
+
+      - name: Verify public release and promoted digest
+        env:
+          GH_TOKEN: ${{ github.token }}
+          EXPECTED_DIGEST: ${{ inputs.expected_image_digest }}
+          RELEASE_TAG: ${{ inputs.release_tag }}
+        run: |
+          set -euo pipefail
+          channel="$(awk -F': ' '$1 == "release_channel" {print $2; exit}' release.yaml)"
+          release_json="$(gh release view "$RELEASE_TAG" \
+            --repo "$GITHUB_REPOSITORY" \
+            --json tagName,isDraft,isPrerelease)"
+          jq -e \
+            --arg tag "$RELEASE_TAG" \
+            --arg channel "$channel" '
+              .tagName == $tag and
+              .isDraft == false and
+              .isPrerelease == ($channel == "prerelease")
+            ' <<<"$release_json" >/dev/null
+          promoted_digest="$(
+            docker buildx imagetools inspect "${IMAGE}:${RELEASE_TAG#v}" \
+              --format '{{json .Manifest}}' | jq -r .digest
+          )"
+          test "$promoted_digest" = "$EXPECTED_DIGEST"

--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -1,9 +1,8 @@
 name: release-artifacts
 
-# One release graph owns binaries, the VM candidate test, the draft GitHub
-# release, and GHCR promotion. A tag is not made visible as a release until the
-# exact candidate binaries pass positive and classified-negative VM tests and
-# the candidate container has been built and verified.
+# The tag-triggered graph builds, verifies, signs, attests, and stages a private
+# draft. It never publishes or promotes. A separate workflow_dispatch-only
+# workflow re-verifies the exact run, commit, digest, and draft before promotion.
 
 on:
   push:
@@ -54,9 +53,9 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           set -euo pipefail
-          reviewer="$(awk -F': ' '$1 == "release_reviewer" {print $2; exit}' release.yaml)"
+          approval_mode="$(awk -F': ' '$1 == "approval_mode" {print $2; exit}' release.yaml)"
           bash scripts/check-production-environment.sh \
-            "$GITHUB_REPOSITORY" production-release "$reviewer"
+            "$GITHUB_REPOSITORY" production-release "$approval_mode"
       - name: Refuse mutation of an already-published release
         if: startsWith(github.ref, 'refs/tags/v')
         env:
@@ -71,6 +70,7 @@ jobs:
           bash scripts/check-production-environment_test.sh
           bash scripts/check-coverage_test.sh
           bash scripts/promote-release_test.sh
+          bash scripts/verify-promotion-inputs_test.sh
           bash scripts/production-readiness-report_test.sh
           bash scripts/verify-release-assets_test.sh
           go vet ./...
@@ -138,7 +138,8 @@ jobs:
             .release_version == $version and
             .slo.campaign_count == 4 and
             .slo.infrastructure_errors == 0 and
-            .reviewer.approved == true
+            .operator.approval_mode == "solo-maintainer" and
+            .operator.confirmed == true
           ' "${source_base}.json" >/dev/null
           cp "${source_base}.json" dist/production-readiness.json
           cp "${source_base}.md" dist/production-readiness.md
@@ -526,36 +527,3 @@ jobs:
             dist/bpfcompat.sbom.cdx.crt
             dist/release-candidate-evidence.json
             dist/production-readiness.*
-
-  promote:
-    name: Promote image and publish release
-    if: startsWith(github.ref, 'refs/tags/v')
-    needs:
-      - build-and-sign
-      - build-candidate-image
-      - assemble-candidate-evidence
-      - stage-draft-release
-    runs-on: ubuntu-latest
-    environment:
-      name: production-release
-    permissions:
-      contents: write
-      packages: write
-    steps:
-      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
-      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
-      - name: Promote the verified image digest
-        env:
-          DIGEST: ${{ needs.build-candidate-image.outputs.digest }}
-          RELEASE_VERSION: ${{ needs.build-and-sign.outputs.version }}
-          RELEASE_CHANNEL: ${{ needs.build-and-sign.outputs.channel }}
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          set -euo pipefail
-          bash scripts/promote-release.sh \
-            "$IMAGE" "$DIGEST" "$RELEASE_VERSION" "$RELEASE_CHANNEL"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once a
 
 ## [Unreleased]
 
+### Changed
+- Split release creation into a tag-triggered candidate workflow and a
+  separately dispatched promotion workflow that re-verifies exact candidate
+  evidence after a 15-minute production wait.
+- Replaced the external-reviewer release contract with an explicit
+  solo-maintainer operator confirmation and documented its residual
+  account-compromise risk.
+- Protected `v*` release tags from updates and deletion while retaining strict
+  pull-request checks with zero required human approvals.
+
 ## [0.4.0-rc.2] - 2026-07-30
 
 ### Fixed

--- a/docs/incident-response-runbook.md
+++ b/docs/incident-response-runbook.md
@@ -7,7 +7,8 @@
 
 ## Immediate Actions
 
-1. Reject or leave pending the `production-release` environment deployment.
+1. Cancel the manual `promote-release` workflow before its 15-minute
+   environment wait completes, or cancel it before the promotion step.
 2. Capture latest evidence artifacts:
    - `evidence/production-tech/*`
    - `.bpfcompat/runs/<latest-run-id>/`
@@ -43,15 +44,17 @@ before changing any alias. Never rebuild or replace an immutable release tag.
 
 1. Keep a draft release private, or mark an already-public candidate as a
    prerelease. Do not delete evidence.
-2. Stop further promotion by rejecting the protected environment deployment.
+2. Stop further promotion by cancelling any queued or running manual
+   `promote-release` workflow.
 3. Repoint only the moving container aliases (`X.Y`, `latest`) to the previous
    signed image digest. Never change an immutable `X.Y.Z` or `X.Y.Z-rc.N` tag.
 4. Verify the restored image signature, provenance, version output, and digest.
 5. Direct Action consumers to the previous immutable commit SHA and installer
    users to the previous stable version.
-6. Record the primary operator, independent reviewer, commands, before/after
-   digests, elapsed recovery time, and verification results. Include the marker
-   `[bpfcompat-rollback-drill:v1]` in a planned drill note.
+6. Record the primary operator, commands, before/after digests, elapsed
+   recovery time, and verification results. Include the marker
+   `[bpfcompat-rollback-drill:v1]` in a planned drill note and record the
+   corresponding `[bpfcompat-solo-promotion:v1]` operator confirmation.
 
 ## Exit Criteria
 
@@ -59,4 +62,5 @@ before changing any alias. Never rebuild or replace an immutable release tag.
 - Production-tech gate returns `ready`.
 - A post-incident note is added under `evidence/production-tech/`.
 - Release aliases resolve to the intended attested digest.
-- The independent reviewer confirms the rollback evidence.
+- The release operator confirms the rollback evidence and explicitly records
+  that no independent human review occurred.

--- a/docs/production-release-process.md
+++ b/docs/production-release-process.md
@@ -6,35 +6,32 @@ validation boundary in
 
 ## Roles
 
-- Release operator: the active project maintainer.
-- Independent release reviewer: the GitHub login recorded as
-  `release_reviewer` in `release.yaml`.
+- Release operator: the GitHub login recorded as `release_operator` in
+  `release.yaml`.
+- Approval mode: `solo-maintainer`.
 
-The selected reviewer is not active until they accept the responsibility in a
-public issue or pull-request comment containing:
-
-```text
-[bpfcompat-release-reviewer-acceptance:v1]
-```
-
-Acceptance covers reviewing candidate evidence, approving or rejecting the
-protected environment, acting as incident backup, and confirming rollback
-evidence. It does not by itself grant maintainer status.
+This mode deliberately has no independent human approval. The same maintainer
+can author, merge, tag, and promote a release. Compromise of that maintainer's
+GitHub account can therefore cross every human boundary. The compensating
+controls are mandatory PR checks, immutable release tags, a separate manual
+promotion dispatch, a 15-minute production wait, exact evidence binding, and
+re-verification immediately before publication.
 
 ## Repository Controls
 
 Before creating a release tag:
 
-1. `main` requires one non-author approval, dismisses stale approvals, requires
-   an up-to-date branch and production checks, and enforces those rules for
-   administrators.
-2. The `production-release` environment requires the recorded reviewer,
-   prevents self-review, disables administrator bypass, and permits only `v*`
-   tag deployments.
-3. `scripts/check-production-environment.sh` passes against the live GitHub
+1. `main` requires a pull request, an up-to-date branch, conversation
+   resolution, and all production checks, and enforces those rules for
+   administrators. It requires zero human approvals.
+2. An active tag ruleset prevents updates or deletion of `v*` release tags.
+3. The `production-release` environment has no required reviewers, imposes a
+   15-minute wait, disables administrator bypass, and permits only `v*` tag
+   deployments.
+4. `scripts/check-production-environment.sh` passes against the live GitHub
    configuration. The tag workflow runs this check before building release
    artifacts.
-4. Required CI and the tagged-release workflow enforce at least 50.0% total Go
+5. Required CI and the tagged-release workflow enforce at least 50.0% total Go
    statement coverage. Raise this floor as sustained coverage improvements
    land; never lower it to make a release pass.
 
@@ -45,19 +42,27 @@ Before creating a release tag:
 2. Set `release_version` to `X.Y.Z-rc.N` and `release_channel` to
    `prerelease`.
 3. Tag the reviewed commit as `vX.Y.Z-rc.N`.
-4. Inspect the draft assets and attested
+4. Wait for `release-artifacts` to finish successfully. It may build, verify,
+   sign, attest, and stage a private draft, but it cannot publish.
+5. Inspect the draft assets and attested
    `release-candidate-evidence.json`.
-5. Approve the protected deployment only if the candidate VM, native ARM64,
-   multi-architecture image, checksum, signature, SBOM, and provenance checks
-   pass.
-6. Verify the release is a GitHub prerelease and only the exact
+6. Dispatch `promote-release` with `--ref vX.Y.Z-rc.N` and the exact release
+   tag, candidate run ID, full commit SHA, image digest, and confirmation text
+   `promote vX.Y.Z-rc.N`. Running on the tag is required by the environment's
+   `v*`-only deployment policy.
+7. The promotion workflow re-verifies the candidate run identity, tag, commit,
+   artifact checksums and attestations, Sigstore signatures, draft state,
+   channel, image signature, digest, and embedded version. Publication occurs
+   only after the environment wait completes.
+8. Verify the release is a GitHub prerelease and only the exact
    `X.Y.Z-rc.N` image tag was created.
 
 ## Graduation Evidence
 
 Download four chronological scheduled campaign artifacts, one expanded Falco
 artifact, the attested candidate evidence, the rollback drill note, and the
-reviewer's written approval into one private working directory. Create an
+operator's written promotion confirmation into one private working directory.
+Create an
 input manifest with paths relative to that directory:
 
 ```json
@@ -86,10 +91,11 @@ input manifest with paths relative to that directory:
     "evidence": "rollback/evidence.md",
     "evidence_sha256": "<sha256>"
   },
-  "reviewer": {
-    "login": "yusuf-demirel4",
-    "approved": true,
-    "evidence": "reviewer/evidence.md",
+  "operator": {
+    "login": "ErenAri",
+    "approval_mode": "solo-maintainer",
+    "confirmed": true,
+    "evidence": "operator/evidence.md",
     "evidence_sha256": "<sha256>"
   }
 }
@@ -114,6 +120,8 @@ test; production evidence must verify the candidate attestation online.
 
 After every operational gate passes, set both `stable_version` and
 `release_version` to `X.Y.Z`, set `release_channel` to `stable`, update stable
-documentation, and tag the reviewed merge commit. The reviewer checks the
-graduation report and draft assets before approving promotion. Only this path
-may update the `X.Y` and `latest` image aliases or GitHub's latest release.
+documentation, and tag the checked merge commit. The operator checks the
+graduation report and draft assets, records
+`[bpfcompat-solo-promotion:v1]`, and dispatches the exact promotion inputs.
+Only this path may update the `X.Y` and `latest` image aliases or GitHub's
+latest release.

--- a/docs/production-slo-runbook.md
+++ b/docs/production-slo-runbook.md
@@ -54,8 +54,8 @@ boundary behavior change requires a new release candidate and restarts the
 window; documentation-only changes do not.
 
 Run the evidence aggregator after downloading the four campaign artifacts,
-the expanded Falco report, candidate evidence, rollback note, and reviewer
-approval:
+the expanded Falco report, candidate evidence, rollback note, and
+solo-maintainer promotion confirmation:
 
 ```bash
 scripts/production-readiness-report.sh \

--- a/docs/production-support-boundary.md
+++ b/docs/production-support-boundary.md
@@ -84,9 +84,11 @@ Every supported release must:
 7. bind the release inputs and VM results into an attested candidate-evidence
    record;
 8. publish signed checksums, SBOM, and build provenance;
-9. pass the configured independent-reviewer check for the protected
-   `production-release` environment; and
-10. promote the verified image digest before making the draft release public.
+9. finish as a private draft without an automatic publication path;
+10. receive a separate exact-input manual promotion dispatch through the
+    15-minute `production-release` environment; and
+11. re-verify the run, tag, commit, assets, attestations, signatures, channel,
+    image digest, and version before making the draft release public.
 
 The release metadata source is [`release.yaml`](../release.yaml). It records
 the current stable version separately from the release candidate and its
@@ -104,12 +106,17 @@ Before the first production claim:
   [production-slo-runbook.md](production-slo-runbook.md);
 - the Falco upstream lane must complete on the expanded vendor-kernel matrix;
 - rollback and incident ownership must be exercised; and
-- at least one external reviewer must be able to approve a release.
+- the release operator must record a deliberate solo-promotion confirmation
+  bound to the final evidence.
+
+There is no separation of duties in `solo-maintainer` mode. The production
+claim must not describe the operator confirmation as independent review.
+Account compromise remains a residual release risk.
 
 Confirmed adoption is an ecosystem-readiness requirement for 1.0, not a
 substitute for these technical controls.
 
 `scripts/production-readiness-report.sh` validates the campaign manifests,
 report hashes, Falco profile coverage, attested release-candidate evidence,
-rollback evidence, and independent approval before producing the graduation
-report.
+rollback evidence, and solo-operator promotion confirmation before producing
+the graduation report.

--- a/docs/public-release-checklist.md
+++ b/docs/public-release-checklist.md
@@ -75,11 +75,14 @@ Required:
 Recommended:
 
 - Branch protection on `main`.
+- An active tag ruleset preventing updates or deletion of `v*` tags.
 - GitHub Security Advisories enabled.
 - Dependabot or dependency-review workflow enabled.
 - Release tags signed by a trusted maintainer key.
-- A protected `production-release` environment with an independent reviewer,
-  self-review prevention, admin bypass disabled, and a `v*` tag policy.
+- A protected `production-release` environment with no human reviewers, a
+  15-minute wait, admin bypass disabled, and a `v*` tag policy.
+- A separate `workflow_dispatch`-only promotion workflow that re-verifies the
+  candidate before publication.
 
 ## Verification
 

--- a/docs/supply-chain.md
+++ b/docs/supply-chain.md
@@ -21,14 +21,19 @@ GitHub repository UI/API (they cannot be set from committed files).
 | Attested candidate promotion record | `.github/workflows/release-artifacts.yml` | tag releases (`v*`) |
 | Release-channel alias isolation | `scripts/promote-release.sh` | tag releases (`v*`) |
 | Protected-environment preflight | `scripts/check-production-environment.sh` | tag releases (`v*`) |
+| Exact-input manual publication | `.github/workflows/promote-release.yml` | explicit `workflow_dispatch` |
 
-The tagged-release workflow is the sole production promotion path. It builds
-candidate binaries once, tests those bytes in a pinned vendor VM, builds and
-verifies the candidate image, stages a draft release, promotes the verified
-image digest, and only then publishes the release. Promotion pauses at the
-`production-release` environment. The workflow refuses tag processing if that
-environment does not require the release reviewer, prevent self-review,
-disable admin bypass, and restrict deployments to `v*` tags.
+The tagged-release workflow builds candidate binaries once, tests those bytes
+in a pinned vendor VM, builds and verifies the candidate image, and stages a
+private draft. It has no publication job. A separate `workflow_dispatch`-only
+workflow is dispatched on the exact `v*` tag and accepts the candidate run ID,
+full commit, image digest, and confirmation phrase. It re-verifies the
+candidate and draft before calling the sole promotion script.
+
+Promotion pauses for 15 minutes at the `production-release` environment. The
+workflows refuse release processing unless that environment has no required
+reviewers, disables administrator bypass, and restricts deployments to `v*`
+tags. This is an explicit solo-maintainer posture, not independent review.
 
 Prereleases publish only their exact `X.Y.Z-rc.N` image tag. Stable aliases
 (`X.Y`, `latest`) are reachable only through the stable release channel.
@@ -48,15 +53,17 @@ sha256sum -c SHA256SUMS
 
 These are not files in the repo. Track their status here.
 
-- [ ] **Production branch protection on `main`**: block force-pushes and
+- [x] **Production branch protection on `main`**: block force-pushes and
       deletions, require conversation resolution and an up-to-date branch,
-      enforce checks for admins, dismiss stale reviews, and require one
-      non-author approval plus the documented production checks. Set via:
+      enforce checks for admins, dismiss stale reviews, require zero human
+      approvals, and require the documented production checks. Set via:
       `gh api -X PUT repos/Kernel-Guard/bpfcompat/branches/main/protection --input -`
-- [ ] **Protected `production-release` environment**: after the selected
-      reviewer accepts the duty in writing, require that reviewer, prevent
-      self-review, disable admin bypass, and allow only `v*` tag deployments.
-      Tag releases fail closed until this configuration exists.
+- [x] **Immutable release tags**: active repository ruleset prevents updates
+      or deletion of `v*` tags, with no bypass actor.
+- [x] **Protected `production-release` environment**: require no human
+      reviewers, apply a 15-minute wait, disable admin bypass, and allow only
+      `v*` tag deployments. Candidate and promotion workflows fail closed
+      until this configuration exists.
 - [x] **Secret scanning + push protection** (wired 2026-06-14): enabled via
       `gh api -X PATCH repos/Kernel-Guard/bpfcompat` with
       `security_and_analysis.secret_scanning` + `secret_scanning_push_protection`.

--- a/release.yaml
+++ b/release.yaml
@@ -1,6 +1,7 @@
 stable_version: 0.3.6
 release_version: 0.4.0-rc.2
 release_channel: prerelease
-release_reviewer: yusuf-demirel4
+release_operator: ErenAri
+approval_mode: solo-maintainer
 minimum_go: 1.25.12
 report_schema: v0.1

--- a/scripts/check-production-environment.sh
+++ b/scripts/check-production-environment.sh
@@ -3,7 +3,7 @@ set -euo pipefail
 
 repo="${1:-}"
 environment="${2:-production-release}"
-reviewer="${3:-}"
+approval_mode="${3:-}"
 
 fail() {
   echo "[production-environment] $*" >&2
@@ -14,26 +14,21 @@ fail() {
   fail "repository must be owner/name"
 [[ "$environment" =~ ^[A-Za-z0-9_.-]+$ ]] ||
   fail "environment name contains unsupported characters"
-[[ "$reviewer" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]] ||
-  fail "reviewer must be a valid GitHub login"
+[[ "$approval_mode" == "solo-maintainer" ]] ||
+  fail "approval mode must be solo-maintainer"
 command -v gh >/dev/null || fail "gh is required"
 
 environment_json="$(gh api "repos/${repo}/environments/${environment}")" ||
   fail "cannot read protected environment ${environment}"
 
-jq -e \
-  --arg reviewer "$reviewer" '
+jq -e '
     .can_admins_bypass == false and
     .deployment_branch_policy.protected_branches == false and
     .deployment_branch_policy.custom_branch_policies == true and
-    any(
-      .protection_rules[];
-      .type == "required_reviewers" and
-      .prevent_self_review == true and
-      any(.reviewers[]?; .type == "User" and .reviewer.login == $reviewer)
-    )
+    ([.protection_rules[] | select(.type == "required_reviewers")] | length == 0) and
+    ([.protection_rules[] | select(.type == "wait_timer" and .wait_timer == 15)] | length == 1)
   ' <<<"$environment_json" >/dev/null ||
-  fail "environment must require ${reviewer}, prevent self-review, disable admin bypass, and use custom deployment policies"
+  fail "environment must have no required reviewers, use a 15-minute wait, disable admin bypass, and use custom deployment policies"
 
 policies_json="$(
   gh api "repos/${repo}/environments/${environment}/deployment-branch-policies"
@@ -43,4 +38,35 @@ jq -e '
 ' <<<"$policies_json" >/dev/null ||
   fail "environment must contain exactly one v* tag deployment policy"
 
-echo "[production-environment] PASS environment=${environment} reviewer=${reviewer}"
+rulesets_json="$(gh api "repos/${repo}/rulesets")" ||
+  fail "cannot read repository rulesets"
+ruleset_id="$(
+  jq -r '
+    [
+      .[] |
+      select(
+        .name == "Immutable release tags" and
+        .target == "tag" and
+        .enforcement == "active"
+      ) |
+      .id
+    ] |
+    if length == 1 then .[0] else empty end
+  ' <<<"$rulesets_json"
+)"
+[[ "$ruleset_id" =~ ^[1-9][0-9]*$ ]] ||
+  fail "repository must have exactly one active Immutable release tags ruleset"
+ruleset_json="$(gh api "repos/${repo}/rulesets/${ruleset_id}")" ||
+  fail "cannot read immutable release tag ruleset"
+jq -e '
+  .target == "tag" and
+  .enforcement == "active" and
+  .conditions.ref_name.include == ["refs/tags/v*"] and
+  .conditions.ref_name.exclude == [] and
+  (.bypass_actors | length == 0) and
+  ([.rules[] | select(.type == "update")] | length == 1) and
+  ([.rules[] | select(.type == "deletion")] | length == 1)
+' <<<"$ruleset_json" >/dev/null ||
+  fail "v* tags must reject updates and deletion without bypass actors"
+
+echo "[production-environment] PASS environment=${environment} mode=${approval_mode} immutable_tags=true"

--- a/scripts/check-production-environment_test.sh
+++ b/scripts/check-production-environment_test.sh
@@ -12,6 +12,10 @@ cat >"$tmp/bin/gh" <<'EOF'
 set -euo pipefail
 if [[ "$*" == *deployment-branch-policies ]]; then
   cat "$POLICIES_FIXTURE"
+elif [[ "$*" == */rulesets/42 ]]; then
+  cat "$RULESET_FIXTURE"
+elif [[ "$*" == */rulesets ]]; then
+  cat "$RULESETS_FIXTURE"
 else
   cat "$ENVIRONMENT_FIXTURE"
 fi
@@ -23,14 +27,11 @@ cat >"$tmp/environment.json" <<'EOF'
   "can_admins_bypass": false,
   "protection_rules": [
     {
-      "type": "required_reviewers",
-      "prevent_self_review": true,
-      "reviewers": [
-        {
-          "type": "User",
-          "reviewer": {"login": "yusuf-demirel4"}
-        }
-      ]
+      "type": "branch_policy"
+    },
+    {
+      "type": "wait_timer",
+      "wait_timer": 15
     }
   ],
   "deployment_branch_policy": {
@@ -46,24 +47,57 @@ cat >"$tmp/policies.json" <<'EOF'
   ]
 }
 EOF
+cat >"$tmp/rulesets.json" <<'EOF'
+[
+  {
+    "id": 42,
+    "name": "Immutable release tags",
+    "target": "tag",
+    "enforcement": "active"
+  }
+]
+EOF
+cat >"$tmp/ruleset.json" <<'EOF'
+{
+  "id": 42,
+  "name": "Immutable release tags",
+  "target": "tag",
+  "enforcement": "active",
+  "conditions": {
+    "ref_name": {
+      "include": ["refs/tags/v*"],
+      "exclude": []
+    }
+  },
+  "bypass_actors": [],
+  "rules": [
+    {"type": "update"},
+    {"type": "deletion"}
+  ]
+}
+EOF
 
 PATH="$tmp/bin:$PATH" \
 ENVIRONMENT_FIXTURE="$tmp/environment.json" \
 POLICIES_FIXTURE="$tmp/policies.json" \
-  "$script" Kernel-Guard/bpfcompat production-release yusuf-demirel4 \
+RULESETS_FIXTURE="$tmp/rulesets.json" \
+RULESET_FIXTURE="$tmp/ruleset.json" \
+  "$script" Kernel-Guard/bpfcompat production-release solo-maintainer \
   >"$tmp/pass.log"
 grep -Fq '[production-environment] PASS' "$tmp/pass.log"
 
 for mutation in \
   '.can_admins_bypass = true' \
-  '.protection_rules[0].prevent_self_review = false' \
-  '.protection_rules[0].reviewers[0].reviewer.login = "someone-else"' \
+  '.protection_rules += [{"type":"required_reviewers","prevent_self_review":true,"reviewers":[]}]' \
+  '.protection_rules[1].wait_timer = 0' \
   '.deployment_branch_policy.custom_branch_policies = false'; do
   jq "$mutation" "$tmp/environment.json" >"$tmp/bad-environment.json"
   if PATH="$tmp/bin:$PATH" \
     ENVIRONMENT_FIXTURE="$tmp/bad-environment.json" \
     POLICIES_FIXTURE="$tmp/policies.json" \
-      "$script" Kernel-Guard/bpfcompat production-release yusuf-demirel4 \
+    RULESETS_FIXTURE="$tmp/rulesets.json" \
+    RULESET_FIXTURE="$tmp/ruleset.json" \
+      "$script" Kernel-Guard/bpfcompat production-release solo-maintainer \
       >/dev/null 2>&1; then
     echo "[production-environment-test] accepted unsafe environment: ${mutation}" >&2
     exit 1
@@ -75,10 +109,29 @@ jq '.branch_policies = [{"name": "main", "type": "branch"}]' \
 if PATH="$tmp/bin:$PATH" \
   ENVIRONMENT_FIXTURE="$tmp/environment.json" \
   POLICIES_FIXTURE="$tmp/bad-policies.json" \
-    "$script" Kernel-Guard/bpfcompat production-release yusuf-demirel4 \
+  RULESETS_FIXTURE="$tmp/rulesets.json" \
+  RULESET_FIXTURE="$tmp/ruleset.json" \
+    "$script" Kernel-Guard/bpfcompat production-release solo-maintainer \
     >/dev/null 2>&1; then
   echo "[production-environment-test] accepted missing tag policy" >&2
   exit 1
 fi
+
+for mutation in \
+  '.bypass_actors = [{"actor_type":"User","actor_id":1,"bypass_mode":"always"}]' \
+  '.rules = [{"type":"deletion"}]' \
+  '.conditions.ref_name.include = ["refs/tags/release-*"]'; do
+  jq "$mutation" "$tmp/ruleset.json" >"$tmp/bad-ruleset.json"
+  if PATH="$tmp/bin:$PATH" \
+    ENVIRONMENT_FIXTURE="$tmp/environment.json" \
+    POLICIES_FIXTURE="$tmp/policies.json" \
+    RULESETS_FIXTURE="$tmp/rulesets.json" \
+    RULESET_FIXTURE="$tmp/bad-ruleset.json" \
+      "$script" Kernel-Guard/bpfcompat production-release solo-maintainer \
+      >/dev/null 2>&1; then
+    echo "[production-environment-test] accepted unsafe tag ruleset: ${mutation}" >&2
+    exit 1
+  fi
+done
 
 echo "[production-environment-test] PASS"

--- a/scripts/check-release-consistency.sh
+++ b/scripts/check-release-consistency.sh
@@ -25,15 +25,19 @@ fail() {
 stable_version="$(field stable_version)"
 release_version="$(field release_version)"
 release_channel="$(field release_channel)"
-release_reviewer="$(field release_reviewer)"
+release_operator="$(field release_operator)"
+approval_mode="$(field approval_mode)"
 minimum_go="$(field minimum_go)"
 report_schema="$(field report_schema)"
 
 [[ -n "$stable_version" && -n "$release_version" && -n "$release_channel" &&
-   -n "$release_reviewer" && -n "$minimum_go" && -n "$report_schema" ]] ||
+   -n "$release_operator" && -n "$approval_mode" &&
+   -n "$minimum_go" && -n "$report_schema" ]] ||
   fail "release metadata fields must not be empty"
-[[ "$release_reviewer" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]] ||
-  fail "release_reviewer must be a valid GitHub login"
+[[ "$release_operator" =~ ^[A-Za-z0-9]([A-Za-z0-9-]{0,37}[A-Za-z0-9])?$ ]] ||
+  fail "release_operator must be a valid GitHub login"
+[[ "$approval_mode" == "solo-maintainer" ]] ||
+  fail "approval_mode must be solo-maintainer"
 
 stable_pattern='^[0-9]+\.[0-9]+\.[0-9]+$'
 prerelease_pattern='^[0-9]+\.[0-9]+\.[0-9]+-rc\.[1-9][0-9]*$'
@@ -83,32 +87,57 @@ for required_control in \
   "Candidate VM positive + classified negative" \
   "Candidate ARM64 CLI native smoke" \
   "Stage production readiness evidence" \
-  "production-release" \
-  "scripts/promote-release.sh" \
-  "Promote image and publish release"; do
+  "Stage draft release"; do
   grep -Fq "$required_control" "$release_workflow" ||
     fail "${release_workflow} is missing required control: ${required_control}"
 done
 
+promotion_workflow=".github/workflows/promote-release.yml"
+[[ -f "$promotion_workflow" ]] ||
+  fail "manual promotion workflow is missing"
+for required_control in \
+  "workflow_dispatch:" \
+  "candidate_run_id:" \
+  "expected_commit:" \
+  "expected_image_digest:" \
+  "Manual promotion confirmation" \
+  "production-release" \
+  "scripts/promote-release.sh" \
+  "Promote image and publish release"; do
+  grep -Fq "$required_control" "$promotion_workflow" ||
+    fail "${promotion_workflow} is missing required control: ${required_control}"
+done
+if grep -Eq '^[[:space:]]+push:' "$promotion_workflow"; then
+  fail "${promotion_workflow} must never have an automatic push trigger"
+fi
+
 unexpected_release_writers="$(
   grep -ERl --include='*.yml' --include='*.yaml' \
     'gh release (create|upload|edit)|softprops/action-gh-release@' .github/workflows |
-    grep -vFx "$release_workflow" || true
+    grep -vFx "$release_workflow" |
+    grep -vFx "$promotion_workflow" || true
 )"
 if [[ -n "$unexpected_release_writers" ]]; then
   printf '%s\n' "$unexpected_release_writers" >&2
-  fail "a workflow other than release-artifacts can publish or mutate releases"
+  fail "an unexpected workflow can publish or mutate releases"
 fi
 
 unexpected_latest_writers="$(
   grep -ERl --include='*.yml' --include='*.yaml' \
     -- '--tag .*IMAGE.*:latest|value=latest' .github/workflows |
-    grep -vFx "$release_workflow" || true
+    grep -vFx "$promotion_workflow" || true
 )"
 if [[ -n "$unexpected_latest_writers" ]]; then
   printf '%s\n' "$unexpected_latest_writers" >&2
-  fail "a workflow other than release-artifacts can publish the production latest image"
+  fail "a workflow other than promote-release can publish the production latest image"
 fi
+
+promotion_callers="$(
+  grep -ERl --include='*.yml' --include='*.yaml' \
+    'scripts/promote-release.sh' .github/workflows || true
+)"
+[[ "$promotion_callers" == "$promotion_workflow" ]] ||
+  fail "only ${promotion_workflow} may invoke scripts/promote-release.sh"
 
 bad_action_refs="$(
   grep -ERn --include='*.md' --include='*.yml' --include='*.yaml' \
@@ -133,4 +162,4 @@ if [[ "${GITHUB_REF_TYPE:-}" == "tag" ]]; then
     fail "release tag ${GITHUB_REF_NAME:-<empty>} does not match metadata ${release_tag}"
 fi
 
-echo "[release-consistency] PASS stable=${stable_version} release=${release_version} channel=${release_channel} go=${minimum_go} schema=${report_schema}"
+echo "[release-consistency] PASS stable=${stable_version} release=${release_version} channel=${release_channel} operator=${release_operator} mode=${approval_mode} go=${minimum_go} schema=${report_schema}"

--- a/scripts/check-release-consistency_test.sh
+++ b/scripts/check-release-consistency_test.sh
@@ -19,12 +19,14 @@ write_metadata() {
   local stable="$1"
   local release="$2"
   local channel="$3"
-  local reviewer="${4:-yusuf-demirel4}"
+  local operator="${4:-ErenAri}"
+  local approval_mode="${5:-solo-maintainer}"
   cat >"$tmp/release.yaml" <<EOF
 stable_version: ${stable}
 release_version: ${release}
 release_channel: ${channel}
-release_reviewer: ${reviewer}
+release_operator: ${operator}
+approval_mode: ${approval_mode}
 minimum_go: 1.25.12
 report_schema: v0.1
 EOF
@@ -41,13 +43,14 @@ GITHUB_REF_TYPE=tag GITHUB_REF_NAME="v${current_release}" \
   BPFCOMPAT_RELEASE_METADATA=release.yaml "$script" >"$tmp/tag.log"
 
 for bad_case in \
-  "0.3.6 0.4.0-rc.1 stable yusuf-demirel4" \
-  "0.3.6 0.4.0 prerelease yusuf-demirel4" \
-  "0.3.6 0.4.0-rc.0 prerelease yusuf-demirel4" \
-  "0.3.6 0.3.6 prerelease yusuf-demirel4" \
-  "0.3.6 0.3.6 stable invalid_login_"; do
-  read -r stable release channel reviewer <<<"$bad_case"
-  write_metadata "$stable" "$release" "$channel" "$reviewer"
+  "0.3.6 0.4.0-rc.1 stable ErenAri solo-maintainer" \
+  "0.3.6 0.4.0 prerelease ErenAri solo-maintainer" \
+  "0.3.6 0.4.0-rc.0 prerelease ErenAri solo-maintainer" \
+  "0.3.6 0.3.6 prerelease ErenAri solo-maintainer" \
+  "0.3.6 0.3.6 stable invalid_login_ solo-maintainer" \
+  "0.3.6 0.3.6 stable ErenAri two-person"; do
+  read -r stable release channel operator approval_mode <<<"$bad_case"
+  write_metadata "$stable" "$release" "$channel" "$operator" "$approval_mode"
   if BPFCOMPAT_RELEASE_METADATA="$tmp/release.yaml" \
     "$script" >"$tmp/bad.log" 2>&1; then
     echo "[release-consistency-test] accepted invalid metadata: ${bad_case}" >&2

--- a/scripts/production-readiness-report.sh
+++ b/scripts/production-readiness-report.sh
@@ -60,7 +60,8 @@ jq -e '
   (.falco | type == "object") and
   (.candidate | type == "object") and
   (.rollback.completed == true) and
-  (.reviewer.approved == true)
+  (.operator.approval_mode == "solo-maintainer") and
+  (.operator.confirmed == true)
 ' "$input" >/dev/null || fail "manifest schema or required gates are invalid"
 
 release_version="$(jq -r '.release_version' "$input")"
@@ -210,15 +211,25 @@ rollback="$(evidence_path "$(jq -r '.rollback.evidence' "$input")")"
 verify_hash "$rollback" "$(jq -r '.rollback.evidence_sha256' "$input")"
 grep -Fq '[bpfcompat-rollback-drill:v1]' "$rollback" ||
   fail "rollback evidence is missing its completion marker"
-review="$(evidence_path "$(jq -r '.reviewer.evidence' "$input")")"
-verify_hash "$review" "$(jq -r '.reviewer.evidence_sha256' "$input")"
-reviewer="$(jq -r '.reviewer.login' "$input")"
-[[ "$reviewer" == "yusuf-demirel4" ]] ||
-  fail "the required independent reviewer is not recorded"
-grep -Fq '[bpfcompat-release-reviewer-acceptance:v1]' "$review" ||
-  fail "reviewer evidence is missing its acceptance marker"
-grep -Fq "$reviewer" "$review" ||
-  fail "reviewer evidence does not identify ${reviewer}"
+operator_evidence="$(evidence_path "$(jq -r '.operator.evidence' "$input")")"
+verify_hash "$operator_evidence" "$(jq -r '.operator.evidence_sha256' "$input")"
+operator="$(jq -r '.operator.login' "$input")"
+approval_mode="$(jq -r '.operator.approval_mode' "$input")"
+metadata_operator="$(
+  awk -F': ' '$1 == "release_operator" {print $2; exit}' release.yaml
+)"
+metadata_approval_mode="$(
+  awk -F': ' '$1 == "approval_mode" {print $2; exit}' release.yaml
+)"
+[[ "$operator" == "$metadata_operator" ]] ||
+  fail "operator does not match release metadata"
+[[ "$approval_mode" == "solo-maintainer" &&
+   "$approval_mode" == "$metadata_approval_mode" ]] ||
+  fail "solo-maintainer approval mode is not recorded"
+grep -Fq '[bpfcompat-solo-promotion:v1]' "$operator_evidence" ||
+  fail "operator evidence is missing its solo-promotion marker"
+grep -Fq "$operator" "$operator_evidence" ||
+  fail "operator evidence does not identify ${operator}"
 
 mkdir -p "$(dirname "$output")"
 mkdir -p "$(dirname "$output_json")"
@@ -231,7 +242,8 @@ mkdir -p "$(dirname "$output_json")"
   echo "- Target executions: ${total_targets}"
   echo "- Infrastructure errors: 0"
   echo "- Target duration p95: ${p95_ms} ms"
-  echo "- Independent reviewer: \`${reviewer}\`"
+  echo "- Release operator: \`${operator}\`"
+  echo "- Approval mode: \`${approval_mode}\` (no independent human approval)"
   echo
   echo "## Scheduled Campaigns"
   echo
@@ -244,7 +256,7 @@ mkdir -p "$(dirname "$output_json")"
   echo "- Falco expanded vendor-kernel matrix: PASS"
   echo "- Attested release candidate: PASS"
   echo "- Rollback and incident exercise: PASS"
-  echo "- Independent release approval: PASS"
+  echo "- Deliberate solo-maintainer promotion confirmation: PASS"
   echo
   echo "Runtime loading, agent, API, registry, SaaS, Firecracker, and virtme-ng are excluded."
 } >"$output"
@@ -259,7 +271,7 @@ candidate_commit="$(jq -r '.commit_sha' "$candidate")"
 candidate_image="$(jq -r '.image' "$candidate")"
 candidate_sha="$(jq -r '.candidate.evidence_sha256' "$input")"
 rollback_sha="$(jq -r '.rollback.evidence_sha256' "$input")"
-review_sha="$(jq -r '.reviewer.evidence_sha256' "$input")"
+operator_sha="$(jq -r '.operator.evidence_sha256' "$input")"
 
 jq -n \
   --arg schema_version "v0.1" \
@@ -279,8 +291,9 @@ jq -n \
   --arg candidate_image "$candidate_image" \
   --arg candidate_sha "$candidate_sha" \
   --arg rollback_sha "$rollback_sha" \
-  --arg reviewer "$reviewer" \
-  --arg review_sha "$review_sha" \
+  --arg operator "$operator" \
+  --arg approval_mode "$approval_mode" \
+  --arg operator_sha "$operator_sha" \
   '{
     schema_version: $schema_version,
     gate_status: $gate_status,
@@ -318,10 +331,11 @@ jq -n \
       completed: true,
       evidence_sha256: $rollback_sha
     },
-    reviewer: {
-      login: $reviewer,
-      approved: true,
-      evidence_sha256: $review_sha
+    operator: {
+      login: $operator,
+      approval_mode: $approval_mode,
+      confirmed: true,
+      evidence_sha256: $operator_sha
     },
     excluded_surfaces: [
       "runtime-loading",

--- a/scripts/production-readiness-report_test.sh
+++ b/scripts/production-readiness-report_test.sh
@@ -58,7 +58,7 @@ for index in 0 1 2 3; do
     '. + [{metadata: $metadata, report: $report}]' <<<"$campaigns")"
 done
 
-mkdir -p "$tmp/falco" "$tmp/candidate" "$tmp/rollback" "$tmp/reviewer"
+mkdir -p "$tmp/falco" "$tmp/candidate" "$tmp/rollback" "$tmp/operator"
 falco_report="$tmp/falco/modern-bpf-compat.json"
 make_report "$falco_report" \
   ubuntu-22.04-5.15 \
@@ -79,14 +79,14 @@ jq -n --arg image "ghcr.io/kernel-guard/bpfcompat@sha256:$(printf 'b%.0s' {1..64
   negative_report_sha256: ("f" * 64)
 }' >"$candidate"
 printf '%s\n' '[bpfcompat-rollback-drill:v1] completed' >"$tmp/rollback/evidence.md"
-printf '%s\n' '[bpfcompat-release-reviewer-acceptance:v1] yusuf-demirel4 approved' >"$tmp/reviewer/evidence.md"
+printf '%s\n' '[bpfcompat-solo-promotion:v1] ErenAri confirmed exact evidence' >"$tmp/operator/evidence.md"
 
 jq -n \
   --argjson campaigns "$campaigns" \
   --arg falco_sha "$(sha256sum "$falco_report" | awk '{print $1}')" \
   --arg candidate_sha "$(sha256sum "$candidate" | awk '{print $1}')" \
   --arg rollback_sha "$(sha256sum "$tmp/rollback/evidence.md" | awk '{print $1}')" \
-  --arg reviewer_sha "$(sha256sum "$tmp/reviewer/evidence.md" | awk '{print $1}')" \
+  --arg operator_sha "$(sha256sum "$tmp/operator/evidence.md" | awk '{print $1}')" \
   '{
     schema_version: "v0.1",
     release_version: "0.4.0",
@@ -107,11 +107,12 @@ jq -n \
       evidence: "rollback/evidence.md",
       evidence_sha256: $rollback_sha
     },
-    reviewer: {
-      login: "yusuf-demirel4",
-      approved: true,
-      evidence: "reviewer/evidence.md",
-      evidence_sha256: $reviewer_sha
+    operator: {
+      login: "ErenAri",
+      approval_mode: "solo-maintainer",
+      confirmed: true,
+      evidence: "operator/evidence.md",
+      evidence_sha256: $operator_sha
     }
   }' >"$tmp/input.json"
 
@@ -125,7 +126,9 @@ jq -e '
   .release_version == "0.4.0" and
   .slo.campaign_count == 4 and
   .slo.infrastructure_errors == 0 and
-  .reviewer.login == "yusuf-demirel4"
+  .operator.login == "ErenAri" and
+  .operator.approval_mode == "solo-maintainer" and
+  .operator.confirmed == true
 ' "$tmp/readiness.json" >/dev/null
 
 jq '.campaigns[3] = .campaigns[2]' "$tmp/input.json" >"$tmp/bad-duplicate.json"

--- a/scripts/verify-promotion-inputs.sh
+++ b/scripts/verify-promotion-inputs.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+evidence="${1:-}"
+repo="${2:-}"
+release_tag="${3:-}"
+run_id="${4:-}"
+run_attempt="${5:-}"
+expected_commit="${6:-}"
+expected_digest="${7:-}"
+expected_channel="${8:-}"
+checksums="${9:-}"
+
+fail() {
+  echo "[promotion-inputs] $*" >&2
+  exit 2
+}
+
+[[ -s "$evidence" ]] || fail "candidate evidence is missing or empty"
+[[ -s "$checksums" ]] || fail "candidate checksums are missing or empty"
+[[ "$repo" =~ ^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$ ]] ||
+  fail "repository must be owner/name"
+[[ "$run_id" =~ ^[1-9][0-9]*$ ]] ||
+  fail "candidate run ID must be a positive integer"
+[[ "$run_attempt" =~ ^[1-9][0-9]*$ ]] ||
+  fail "candidate run attempt must be a positive integer"
+[[ "$expected_commit" =~ ^[0-9a-f]{40}$ ]] ||
+  fail "expected commit must be a full lowercase SHA"
+[[ "$expected_digest" =~ ^sha256:[0-9a-f]{64}$ ]] ||
+  fail "expected image digest must be sha256 followed by 64 lowercase hexadecimal characters"
+[[ "$expected_channel" == "stable" || "$expected_channel" == "prerelease" ]] ||
+  fail "expected channel must be stable or prerelease"
+
+case "$expected_channel" in
+  stable)
+    [[ "$release_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ ]] ||
+      fail "stable promotion requires a vX.Y.Z tag"
+    ;;
+  prerelease)
+    [[ "$release_tag" =~ ^v[0-9]+\.[0-9]+\.[0-9]+-rc\.[1-9][0-9]*$ ]] ||
+      fail "prerelease promotion requires a vX.Y.Z-rc.N tag"
+    ;;
+esac
+
+checksums_sha256="$(sha256sum "$checksums" | awk '{print $1}')"
+expected_image="ghcr.io/kernel-guard/bpfcompat@${expected_digest}"
+
+jq -e \
+  --arg repo "$repo" \
+  --arg tag "$release_tag" \
+  --argjson run_id "$run_id" \
+  --argjson run_attempt "$run_attempt" \
+  --arg commit "$expected_commit" \
+  --arg channel "$expected_channel" \
+  --arg image "$expected_image" \
+  --arg checksums_sha256 "$checksums_sha256" '
+    .schema_version == "v0.1" and
+    .repository == $repo and
+    (.workflow | contains(".github/workflows/release-artifacts.yml@")) and
+    .workflow_run_id == $run_id and
+    .workflow_run_attempt == $run_attempt and
+    .commit_sha == $commit and
+    .tag == $tag and
+    .channel == $channel and
+    .image == $image and
+    .checksums_sha256 == $checksums_sha256 and
+    (.positive_report_sha256 | test("^[0-9a-f]{64}$")) and
+    (.negative_report_sha256 | test("^[0-9a-f]{64}$")) and
+    (.generated_at | fromdateiso8601 > 0)
+  ' "$evidence" >/dev/null ||
+  fail "candidate evidence does not bind the exact promotion inputs"
+
+echo "[promotion-inputs] PASS tag=${release_tag} run=${run_id}/${run_attempt} commit=${expected_commit} image=${expected_image}"

--- a/scripts/verify-promotion-inputs_test.sh
+++ b/scripts/verify-promotion-inputs_test.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+script="${ROOT_DIR}/scripts/verify-promotion-inputs.sh"
+tmp="$(mktemp -d)"
+trap 'rm -rf "$tmp"' EXIT
+
+commit="$(printf 'a%.0s' {1..40})"
+digest="sha256:$(printf 'b%.0s' {1..64})"
+printf 'fixture checksums\n' >"$tmp/SHA256SUMS"
+checksums_sha="$(sha256sum "$tmp/SHA256SUMS" | awk '{print $1}')"
+
+jq -n \
+  --arg commit "$commit" \
+  --arg image "ghcr.io/kernel-guard/bpfcompat@${digest}" \
+  --arg checksums "$checksums_sha" '{
+    schema_version: "v0.1",
+    repository: "Kernel-Guard/bpfcompat",
+    workflow: "Kernel-Guard/bpfcompat/.github/workflows/release-artifacts.yml@refs/tags/v0.4.0-rc.3",
+    workflow_run_id: 12345,
+    workflow_run_attempt: 2,
+    commit_sha: $commit,
+    tag: "v0.4.0-rc.3",
+    channel: "prerelease",
+    image: $image,
+    checksums_sha256: $checksums,
+    positive_report_sha256: ("c" * 64),
+    negative_report_sha256: ("d" * 64),
+    generated_at: "2026-07-30T12:00:00Z"
+  }' >"$tmp/evidence.json"
+
+"$script" "$tmp/evidence.json" Kernel-Guard/bpfcompat \
+  v0.4.0-rc.3 12345 2 "$commit" "$digest" prerelease \
+  "$tmp/SHA256SUMS" >"$tmp/pass.log"
+grep -Fq '[promotion-inputs] PASS' "$tmp/pass.log"
+
+for mutation in \
+  '.workflow_run_id = 999' \
+  '.workflow_run_attempt = 1' \
+  '.commit_sha = ("e" * 40)' \
+  '.tag = "v0.4.0-rc.4"' \
+  '.channel = "stable"' \
+  '.image = "ghcr.io/kernel-guard/bpfcompat@sha256:" + ("f" * 64)' \
+  '.checksums_sha256 = ("0" * 64)' \
+  '.workflow = "Kernel-Guard/bpfcompat/.github/workflows/other.yml@refs/tags/v0.4.0-rc.3"'; do
+  jq "$mutation" "$tmp/evidence.json" >"$tmp/bad.json"
+  if "$script" "$tmp/bad.json" Kernel-Guard/bpfcompat \
+    v0.4.0-rc.3 12345 2 "$commit" "$digest" prerelease \
+    "$tmp/SHA256SUMS" >/dev/null 2>&1; then
+    echo "[promotion-inputs-test] accepted mutated evidence: ${mutation}" >&2
+    exit 1
+  fi
+done
+
+if "$script" "$tmp/evidence.json" Kernel-Guard/bpfcompat \
+  v0.4.0 12345 2 "$commit" "$digest" prerelease \
+  "$tmp/SHA256SUMS" >/dev/null 2>&1; then
+  echo "[promotion-inputs-test] accepted stable tag for prerelease channel" >&2
+  exit 1
+fi
+
+echo "[promotion-inputs-test] PASS"


### PR DESCRIPTION
## What changed

- split tag-triggered candidate staging from manual release promotion
- require exact tag, candidate run, commit, digest, and confirmation inputs
- re-verify artifacts, attestations, Sigstore signatures, draft state, channel, image signature, digest, and version before publication
- replace the Yusuf reviewer contract with explicit solo-maintainer operator evidence
- validate the 15-minute no-reviewer production environment and immutable v* tag ruleset
- document the residual same-account compromise risk

## Why

The repository is maintained by one person and the live environment no longer has a human reviewer. The previous contract would fail future tag builds, while simply removing that check would make releases publish automatically. This keeps a deliberate, fail-closed manual boundary without claiming independent review.

## Validation

- focused shell regression tests
- workflow YAML parsing and actionlint
- check-release-consistency and live environment preflight
- check-docs-drift
- go vet
- go test -race with 51.8% total coverage
- govulncheck: no vulnerabilities
- production-tech-check: ready
