### PR TITLE
Prepare v0.4.0-rc.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html) once a
 
 ## [Unreleased]
 
+## [0.4.0-rc.3] - 2026-07-30
+
 ### Changed
 - Split release creation into a tag-triggered candidate workflow and a
   separately dispatched promotion workflow that re-verifies exact candidate

--- a/release.yaml
+++ b/release.yaml
@@ -1,5 +1,5 @@
 stable_version: 0.3.6
-release_version: 0.4.0-rc.2
+release_version: 0.4.0-rc.3
 release_channel: prerelease
 release_operator: ErenAri
 approval_mode: solo-maintainer


### PR DESCRIPTION
## What changed

- advance prerelease metadata from v0.4.0-rc.2 to v0.4.0-rc.3
- publish the solo-release promotion redesign in the RC3 changelog entry

## Why

RC3 exercises the newly merged candidate-only and separately dispatched promotion workflow before the production evidence window begins.

## Validation

- make check-release-consistency
- check-release-consistency regression tests
- generated documentation drift check
- git diff --check
