### PR TITLE
ci: migrate SBOM attestations to actions/attest

### DIFF
--- a/.github/workflows/release-artifacts.yml
+++ b/.github/workflows/release-artifacts.yml
@@ -179,7 +179,7 @@ jobs:
             dist/production-readiness.md
       - name: Attest candidate SBOM
         if: startsWith(github.ref, 'refs/tags/v')
-        uses: actions/attest-sbom@c604332985a26aa8cf1bdc465b92731239ec6b9e # v4.1.0
+        uses: actions/attest@508db95dd578ae2727ebd6217d5ba78e4fbda05d # v4.2.1
         with:
           subject-path: dist/bpfcompat-linux-amd64
           sbom-path: dist/bpfcompat.sbom.cdx.json


### PR DESCRIPTION
## Summary
- replace the deprecated `actions/attest-sbom` wrapper with GitHub’s supported `actions/attest` action
- pin `actions/attest` v4.2.1 to its full commit SHA
- preserve the existing SBOM subject and CycloneDX inputs exactly

## Verification
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.10 .github/workflows/release-artifacts.yml`
- `./scripts/check-release-consistency.sh`
- `git diff --check`

This is release-tooling maintenance on `main`; the immutable `v0.4.0-rc.3` tag and candidate digest are unchanged.