### PR TITLE
fix: accept generated profile scalars in image prefetch

### DIFF
--- a/scripts/fetch-matrix-images.sh
+++ b/scripts/fetch-matrix-images.sh
@@ -34,6 +34,24 @@ failed=0
 
 echo "[fetch-matrix-images] matrix=$MATRIX dry_run=$DRY_RUN"
 
+yaml_scalar() {
+  local key="$1"
+  local path="$2"
+  awk -v key="$key" '
+    $1 == key ":" {
+      value = $0
+      sub(/^[[:space:]]*[A-Za-z0-9_]+:[[:space:]]*/, "", value)
+      first = substr(value, 1, 1)
+      last = substr(value, length(value), 1)
+      if ((first == "\"" && last == "\"") || (first == "\047" && last == "\047")) {
+        value = substr(value, 2, length(value) - 2)
+      }
+      print value
+      exit
+    }
+  ' "$path"
+}
+
 while IFS= read -r profile_id; do
   [[ -z "$profile_id" ]] && continue
   total=$((total + 1))
@@ -45,9 +63,9 @@ while IFS= read -r profile_id; do
     continue
   fi
 
-  source_url="$(awk -F'"' '/source_url:/ {print $2; exit}' "$profile_path")"
-  local_path="$(awk -F'"' '/local_path:/ {print $2; exit}' "$profile_path")"
-  distro="$(awk -F': ' '/^distro:/ {gsub(/"/, "", $2); print $2; exit}' "$profile_path")"
+  source_url="$(yaml_scalar source_url "$profile_path")"
+  local_path="$(yaml_scalar local_path "$profile_path")"
+  distro="$(yaml_scalar distro "$profile_path")"
 
   if [[ -z "$local_path" ]]; then
     echo "[fetch-matrix-images] ${profile_id}: missing local_path in profile"
@@ -97,4 +115,3 @@ echo "  failed:                 $failed"
 if [[ "$failed" -gt 0 ]]; then
   exit 2
 fi
-

--- a/scripts/fetch-matrix-images_test.sh
+++ b/scripts/fetch-matrix-images_test.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+SCRIPT="$ROOT_DIR/scripts/fetch-matrix-images.sh"
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+mkdir -p "$TMP/bin" "$TMP/matrices" "$TMP/scripts" "$TMP/vm/profiles"
+cp "$SCRIPT" "$TMP/scripts/fetch-matrix-images.sh"
+
+cat >"$TMP/bin/bpfcompat" <<'FAKE'
+#!/usr/bin/env bash
+set -euo pipefail
+[[ "$*" == "profile list --matrix matrices/test.yaml" ]]
+printf '%s\n' quoted-profile generated-profile
+FAKE
+chmod +x "$TMP/bin/bpfcompat"
+
+cat >"$TMP/matrices/test.yaml" <<'YAML'
+name: test
+profiles:
+  - id: quoted-profile
+    required: true
+  - id: generated-profile
+    required: true
+YAML
+
+cat >"$TMP/vm/profiles/quoted-profile.yaml" <<'YAML'
+id: quoted-profile
+distro: "amazon-linux"
+image:
+  source_url: "https://example.invalid/quoted.qcow2"
+  local_path: "vm/cache/quoted.qcow2"
+YAML
+
+cat >"$TMP/vm/profiles/generated-profile.yaml" <<'YAML'
+id: generated-profile
+distro: almalinux
+image:
+    source_url: https://example.invalid/generated.qcow2
+    local_path: vm/cache/generated.qcow2
+YAML
+
+output="$(
+  cd "$TMP"
+  BPFCOMPAT_BIN=./bin/bpfcompat \
+  BPFCOMPAT_MATRIX=matrices/test.yaml \
+  BPFCOMPAT_DRY_RUN=1 \
+    bash scripts/fetch-matrix-images.sh
+)"
+
+grep -Fq "quoted-profile: would download -> vm/cache/quoted.qcow2" <<<"$output"
+grep -Fq "generated-profile: would download -> vm/cache/generated.qcow2" <<<"$output"
+grep -Fq "failed:                 0" <<<"$output"
+
+echo "[fetch-matrix-images-test] PASS"


### PR DESCRIPTION
## Summary
- parse quoted and unquoted YAML scalars in `fetch-matrix-images.sh`
- add a regression covering both hand-authored and `yaml.Marshal`-generated profile formatting

## Root cause
Manual enterprise refresh run [30556641513](https://github.com/Kernel-Guard/bpfcompat/actions/runs/30556641513) failed before VM execution because the prefetch helper split values only on double quotes. Generated sweep profiles use valid unquoted YAML scalars, so all three were falsely reported as missing `local_path`.

## Verification
- `bash scripts/fetch-matrix-images_test.sh`
- `shellcheck scripts/fetch-matrix-images.sh scripts/fetch-matrix-images_test.sh`
- real six-target matrix dry-run reports all profile paths with zero failures
- `git diff --check`

After merge, the same hosted KVM matrix will be re-dispatched.