### PR TITLE
ci: add protected release rollback drill

### DIFF
--- a/.github/workflows/rollback-drill.yml
+++ b/.github/workflows/rollback-drill.yml
@@ -1,0 +1,267 @@
+name: rollback-drill
+
+# Deliberate moving-alias recovery exercise. This workflow can write only to
+# GHCR, never Git refs or releases, and accepts only a rollback-drill-* alias.
+# Both immutable endpoints are signature/provenance/version verified before
+# the alias moves. The alias is restored to the known-good digest on success
+# and on ordinary step failure.
+
+on:
+  workflow_dispatch:
+    inputs:
+      drill_alias:
+        description: Dedicated rollback-drill-vX.Y.Z-rc.N alias.
+        required: true
+        type: string
+      before_digest:
+        description: Known-good immutable sha256 image digest.
+        required: true
+        type: string
+      candidate_digest:
+        description: Candidate immutable sha256 image digest.
+        required: true
+        type: string
+      before_version:
+        description: Version embedded in the known-good image.
+        required: true
+        type: string
+      candidate_version:
+        description: Version embedded in the candidate image.
+        required: true
+        type: string
+      before_identity:
+        description: Exact Sigstore workflow identity for the known-good image.
+        required: true
+        type: string
+      candidate_identity:
+        description: Exact Sigstore workflow identity for the candidate image.
+        required: true
+        type: string
+      confirmation:
+        description: Type rollback drill followed by the drill alias.
+        required: true
+        type: string
+
+permissions:
+  contents: read
+
+concurrency:
+  group: production-rollback-drill
+  cancel-in-progress: false
+
+env:
+  IMAGE: ghcr.io/kernel-guard/bpfcompat
+
+jobs:
+  rollback:
+    name: Exercise moving-alias rollback
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    environment:
+      name: production-drill
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+
+      - name: Validate exact drill inputs
+        env:
+          BEFORE_DIGEST: ${{ inputs.before_digest }}
+          BEFORE_IDENTITY: ${{ inputs.before_identity }}
+          BEFORE_VERSION: ${{ inputs.before_version }}
+          CANDIDATE_DIGEST: ${{ inputs.candidate_digest }}
+          CANDIDATE_IDENTITY: ${{ inputs.candidate_identity }}
+          CANDIDATE_VERSION: ${{ inputs.candidate_version }}
+          CONFIRMATION: ${{ inputs.confirmation }}
+          DRILL_ALIAS: ${{ inputs.drill_alias }}
+        run: |
+          set -euo pipefail
+          test "$GITHUB_REF" = "refs/heads/main"
+          [[ "$DRILL_ALIAS" =~ ^rollback-drill-v[0-9]+\.[0-9]+\.[0-9]+-rc\.[0-9]+$ ]]
+          [[ "$BEFORE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
+          [[ "$CANDIDATE_DIGEST" =~ ^sha256:[0-9a-f]{64}$ ]]
+          [[ "$BEFORE_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]
+          [[ "$CANDIDATE_VERSION" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$ ]]
+          identity_prefix="https://github.com/${GITHUB_REPOSITORY}/.github/workflows/"
+          [[ "$BEFORE_IDENTITY" == "${identity_prefix}"*"@refs/tags/v"* ]]
+          [[ "$CANDIDATE_IDENTITY" == "${identity_prefix}"*"@refs/tags/v"* ]]
+          test "$CONFIRMATION" = "rollback drill ${DRILL_ALIAS}"
+
+      - uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
+
+      - uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
+        with:
+          cosign-release: "v2.6.3"
+
+      - name: Verify immutable rollback endpoints
+        env:
+          BEFORE_DIGEST: ${{ inputs.before_digest }}
+          BEFORE_IDENTITY: ${{ inputs.before_identity }}
+          BEFORE_VERSION: ${{ inputs.before_version }}
+          CANDIDATE_DIGEST: ${{ inputs.candidate_digest }}
+          CANDIDATE_IDENTITY: ${{ inputs.candidate_identity }}
+          CANDIDATE_VERSION: ${{ inputs.candidate_version }}
+        run: |
+          set -euo pipefail
+          verify_endpoint() {
+            local digest="$1"
+            local expected_version="$2"
+            local identity="$3"
+            cosign verify \
+              --certificate-identity "$identity" \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+              "${IMAGE}@${digest}" >/dev/null
+            cosign verify-attestation \
+              --type https://slsa.dev/provenance/v1 \
+              --certificate-identity "$identity" \
+              --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+              "${IMAGE}@${digest}" >/dev/null
+            actual_version="$(
+              docker run --rm "${IMAGE}@${digest}" version --json | jq -r .version
+            )"
+            test "$actual_version" = "$expected_version"
+          }
+          verify_endpoint "$BEFORE_DIGEST" "$BEFORE_VERSION" "$BEFORE_IDENTITY"
+          verify_endpoint "$CANDIDATE_DIGEST" "$CANDIDATE_VERSION" "$CANDIDATE_IDENTITY"
+
+      - name: Promote drill alias and recover
+        env:
+          BEFORE_DIGEST: ${{ inputs.before_digest }}
+          BEFORE_VERSION: ${{ inputs.before_version }}
+          CANDIDATE_DIGEST: ${{ inputs.candidate_digest }}
+          CANDIDATE_VERSION: ${{ inputs.candidate_version }}
+          DRILL_ALIAS: ${{ inputs.drill_alias }}
+        run: |
+          set -euo pipefail
+          alias_ref="${IMAGE}:${DRILL_ALIAS}"
+          evidence_dir="evidence/rollback"
+          mkdir -p "$evidence_dir"
+
+          latest_before="$(
+            docker buildx imagetools inspect "${IMAGE}:latest" \
+              --format '{{json .Manifest}}' | jq -r .digest
+          )"
+          test "$latest_before" = "$BEFORE_DIGEST"
+
+          docker buildx imagetools create \
+            --tag "$alias_ref" "${IMAGE}@${BEFORE_DIGEST}"
+          setup_digest="$(
+            docker buildx imagetools inspect "$alias_ref" \
+              --format '{{json .Manifest}}' | jq -r .digest
+          )"
+          test "$setup_digest" = "$BEFORE_DIGEST"
+
+          promoted=0
+          recover_on_error() {
+            if [[ "$promoted" == "1" ]]; then
+              docker buildx imagetools create \
+                --tag "$alias_ref" "${IMAGE}@${BEFORE_DIGEST}" || true
+            fi
+          }
+          trap recover_on_error ERR
+
+          promote_started_ms="$(date +%s%3N)"
+          docker buildx imagetools create \
+            --tag "$alias_ref" "${IMAGE}@${CANDIDATE_DIGEST}"
+          promote_completed_ms="$(date +%s%3N)"
+          promoted=1
+          promoted_digest="$(
+            docker buildx imagetools inspect "$alias_ref" \
+              --format '{{json .Manifest}}' | jq -r .digest
+          )"
+          test "$promoted_digest" = "$CANDIDATE_DIGEST"
+          test "$(
+            docker run --rm "${IMAGE}@${promoted_digest}" version --json | jq -r .version
+          )" = "$CANDIDATE_VERSION"
+
+          rollback_started_ms="$(date +%s%3N)"
+          docker buildx imagetools create \
+            --tag "$alias_ref" "${IMAGE}@${BEFORE_DIGEST}"
+          rollback_completed_ms="$(date +%s%3N)"
+          promoted=0
+          trap - ERR
+
+          rolled_back_digest="$(
+            docker buildx imagetools inspect "$alias_ref" \
+              --format '{{json .Manifest}}' | jq -r .digest
+          )"
+          test "$rolled_back_digest" = "$BEFORE_DIGEST"
+          test "$(
+            docker run --rm "${IMAGE}@${rolled_back_digest}" version --json | jq -r .version
+          )" = "$BEFORE_VERSION"
+          latest_after="$(
+            docker buildx imagetools inspect "${IMAGE}:latest" \
+              --format '{{json .Manifest}}' | jq -r .digest
+          )"
+          test "$latest_after" = "$latest_before"
+
+          promotion_elapsed_ms="$((promote_completed_ms - promote_started_ms))"
+          recovery_elapsed_ms="$((rollback_completed_ms - rollback_started_ms))"
+          completed_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+          jq -n \
+            --arg schema_version "v0.1" \
+            --arg marker "[bpfcompat-rollback-drill:v1]" \
+            --arg operator "$GITHUB_ACTOR" \
+            --arg workflow_run_id "$GITHUB_RUN_ID" \
+            --arg completed_at "$completed_at" \
+            --arg alias "$alias_ref" \
+            --arg before_digest "$BEFORE_DIGEST" \
+            --arg candidate_digest "$CANDIDATE_DIGEST" \
+            --arg final_digest "$rolled_back_digest" \
+            --arg latest_digest "$latest_after" \
+            --argjson promotion_elapsed_ms "$promotion_elapsed_ms" \
+            --argjson recovery_elapsed_ms "$recovery_elapsed_ms" \
+            '{
+              schema_version: $schema_version,
+              marker: $marker,
+              operator: $operator,
+              workflow_run_id: ($workflow_run_id | tonumber),
+              completed_at: $completed_at,
+              alias: $alias,
+              before_digest: $before_digest,
+              candidate_digest: $candidate_digest,
+              final_digest: $final_digest,
+              latest_digest: $latest_digest,
+              promotion_elapsed_ms: $promotion_elapsed_ms,
+              recovery_elapsed_ms: $recovery_elapsed_ms,
+              signature_verified: true,
+              provenance_verified: true,
+              version_verified: true
+            }' >"$evidence_dir/evidence.json"
+
+          {
+            echo "# bpfcompat Release-Promotion Rollback Drill"
+            echo
+            echo "[bpfcompat-rollback-drill:v1]"
+            echo
+            echo "- Operator: \`$GITHUB_ACTOR\`"
+            echo "- Workflow run: \`$GITHUB_RUN_ID\`"
+            echo "- Completed: \`$completed_at\`"
+            echo "- Drill alias: \`$alias_ref\`"
+            echo "- Known-good digest: \`$BEFORE_DIGEST\`"
+            echo "- Candidate digest: \`$CANDIDATE_DIGEST\`"
+            echo "- Final digest: \`$rolled_back_digest\`"
+            echo "- Promotion elapsed: \`${promotion_elapsed_ms} ms\`"
+            echo "- Recovery elapsed: \`${recovery_elapsed_ms} ms\`"
+            echo "- Signature verification: PASS"
+            echo "- SLSA v1 provenance verification: PASS"
+            echo "- Embedded version verification: PASS"
+            echo "- Protected \`latest\` alias unchanged: \`$latest_after\`"
+          } >"$evidence_dir/evidence.md"
+          cat "$evidence_dir/evidence.md" >>"$GITHUB_STEP_SUMMARY"
+
+      - name: Upload rollback evidence
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7
+        with:
+          name: rollback-drill-${{ github.run_id }}
+          if-no-files-found: error
+          path: evidence/rollback/**
+

--- a/docs/production-release-process.md
+++ b/docs/production-release-process.md
@@ -59,6 +59,20 @@ Before creating a release tag:
 
 ## Graduation Evidence
 
+Before assembling the graduation directory, run the protected
+`rollback-drill` workflow from `main`. Supply a dedicated
+`rollback-drill-vX.Y.Z-rc.N` alias, the immutable known-good and candidate
+digests, their embedded versions, their exact Sigstore workflow identities,
+and confirmation text `rollback drill rollback-drill-vX.Y.Z-rc.N`.
+`production-drill` adds a five-minute wait and permits only `main`.
+
+The workflow verifies both signatures, SLSA v1 provenance records, and
+embedded versions before moving the drill-only alias known-good → candidate →
+known-good. It records the promotion and recovery times, proves `latest` was
+unchanged, leaves the drill alias on the known-good digest, and uploads
+`evidence.{md,json}` containing `[bpfcompat-rollback-drill:v1]`. Download that
+artifact as the rollback drill note.
+
 Download four chronological scheduled campaign artifacts, one expanded Falco
 artifact, the attested candidate evidence, the rollback drill note, and the
 operator's written promotion confirmation into one private working directory.

--- a/docs/supply-chain.md
+++ b/docs/supply-chain.md
@@ -22,6 +22,7 @@ GitHub repository UI/API (they cannot be set from committed files).
 | Release-channel alias isolation | `scripts/promote-release.sh` | tag releases (`v*`) |
 | Protected-environment preflight | `scripts/check-production-environment.sh` | tag releases (`v*`) |
 | Exact-input manual publication | `.github/workflows/promote-release.yml` | explicit `workflow_dispatch` |
+| Protected moving-alias rollback drill | `.github/workflows/rollback-drill.yml` | explicit `workflow_dispatch` from `main` |
 
 The tagged-release workflow builds candidate binaries once, tests those bytes
 in a pinned vendor VM, builds and verifies the candidate image, and stages a


### PR DESCRIPTION
## Summary
- add a manual GHCR moving-alias rollback exercise with least-privilege `packages: write`
- restrict mutation to a `rollback-drill-vX.Y.Z-rc.N` alias and exact digest/version/identity inputs
- verify Sigstore signatures, SLSA v1 provenance, and embedded versions before mutation
- exercise known-good → candidate → known-good with ordinary-error recovery, prove `latest` is unchanged, and upload Markdown/JSON evidence
- document the protected `production-drill` contract and final evidence flow

## Why
A local drill attempt was correctly denied because the maintainer token lacks `write:packages`; no alias was created. The repository-scoped Actions token is the least-privilege path and provides a durable run/audit artifact.

## Verification
- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.10 .github/workflows/rollback-drill.yml`
- `make check-docs-drift`
- `./scripts/check-release-consistency.sh`
- `git diff --check`

After merge, `production-drill` will be configured with a five-minute wait, no reviewers/admin bypass, and a `main`-only policy before dispatch.