### PR TITLE
test: include required baseline in enterprise refresh

### DIFF
--- a/matrices/pre-campaign-enterprise-refresh.yaml
+++ b/matrices/pre-campaign-enterprise-refresh.yaml
@@ -1,5 +1,9 @@
 name: pre-campaign-enterprise-refresh
 profiles:
+  # The latest-kernel functional manifest requires this stable Ubuntu baseline.
+  - id: ubuntu-24.04-6.8
+    required: true
+    timeout: 20m
   - id: almalinux-9-5.14-k5.14.0-687.29.1.el9_8
     required: true
     timeout: 20m


### PR DESCRIPTION
## Summary

- include the Ubuntu 24.04 baseline required by the fixed latest-kernel functional manifest
- keep all six enterprise refresh targets required
- turn the pre-campaign refresh into a seven-target functional gate

## Why

Run 30557267883 passed image prefetch and runnable-matrix generation, then failed closed before starting a VM because `ubuntu-24.04-6.8` was not present in the custom matrix. This restores the manifest/matrix contract without weakening the functional check.

## Validation

- matrix/manifest profile contract check: PASS
- all seven profile files exist: PASS
- `go test ./internal/manifest ./internal/runner`: PASS
- `make check-docs-drift check-release-consistency`: PASS
- `git diff --check`: PASS