### PR TITLE
ci: use attestation path in installer canary

### DIFF
--- a/.github/workflows/release-candidate-canary.yml
+++ b/.github/workflows/release-candidate-canary.yml
@@ -75,14 +75,15 @@ jobs:
         with:
           ref: ${{ env.CANDIDATE_COMMIT }}
 
-      - uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
-        with:
-          cosign-release: "v2.6.3"
-
       - name: Install and verify the exact prerelease
         shell: bash
         run: |
           set -euo pipefail
+          # Exercise the installer's independent GitHub-attestation path.
+          # Container signature/provenance verification is covered by the
+          # separate container job; avoiding a second cosign bootstrap also
+          # removes a redundant release-download failure point.
+          gh attestation --help >/dev/null
           install_root="$RUNNER_TEMP/bpfcompat-rc-install"
           mkdir -p "$install_root/bin" "$install_root/libexec" evidence
           BPFCOMPAT_VERSION="$CANDIDATE_TAG" \
@@ -109,7 +110,7 @@ jobs:
               commit: $commit,
               installer: $installer,
               checksum_verified: true,
-              sigstore_verified: true,
+              github_attestations_verified: true,
               validator_installed: true
             }' >evidence/clean-install.json
 


### PR DESCRIPTION
## Summary

- make the clean-install canary exercise the installer's GitHub build-attestation path
- keep cosign signature/provenance verification in the independent container job
- remove a redundant cosign bootstrap download from the installer lane

## Root cause

Immediate canary run 30559109069 failed before the installer ran because the upstream cosign setup action received `curl: (35) Recv failure: Connection reset by peer` downloading v2.6.3. Its pinned installer uses plain `--retry`, which does not retry this transport failure. The same setup action succeeded in the container lane seconds later, proving this was not a bad pin.

The published Action lane already proved `gh attestation` is available on the hosted image. `scripts/install.sh` treats either verified cosign signatures or GitHub build attestations as mandatory cryptographic verification, so selecting the latter is an equally fail-closed path with one fewer network bootstrap.

## Validation

- actionlint with ShellCheck: PASS
- `make check-release-consistency`: PASS
- `git diff --check`: PASS