### PR TITLE
ci: exercise RC3 in consumer canary

### DIFF
--- a/.github/workflows/consumer-canary.yml
+++ b/.github/workflows/consumer-canary.yml
@@ -13,12 +13,13 @@ name: consumer-canary
 #
 # Two jobs, one per resolution path:
 #
-#   prebuilt      pins the v0.3.6 release commit, like falcosecurity/libs.
+#   prebuilt      pins the active v0.4.0-rc.3 release commit, matching the
+#                 release candidate being exercised by downstream lanes.
 #                 A SHA that matches a release tag must resolve to prebuilt,
-#                 checksum-verified binaries. This release predates the
-#                 Action's attestation-enforcement change. The job deliberately
-#                 does NOT install libbpf-dev; if resolution regresses and it
-#                 falls back to a source build, the compile fails here.
+#                 checksum- and attestation-verified binaries. The job
+#                 deliberately does NOT install libbpf-dev; if resolution
+#                 regresses and it falls back to a source build, the compile
+#                 fails here.
 #
 #   source-build  pins @main, which is not a release, forcing the source
 #                 path with exactly the dependencies we document. If a
@@ -72,7 +73,7 @@ jobs:
           fi
 
       - name: Validate via the published action (pinned to a release commit)
-        uses: Kernel-Guard/bpfcompat@f1ba21fd4e098d483961e9e9355a51ae78273422 # v0.3.6
+        uses: Kernel-Guard/bpfcompat@cba1e09537f2e05e4ba7278efdb5c2d044d1889b # v0.4.0-rc.3
         with:
           # Command mode with no artifact and no shipped binary, so this job
           # needs no compiler at all: the example .bpf.o objects are built,


### PR DESCRIPTION
## What changed

Retarget the prebuilt consumer-canary job from the v0.3.6 release commit to the exact v0.4.0-rc.3 commit.

## Why

The August 2 schedule exposed a v0.3.6 Action bug: its checksum step validates an arm64 entry that the amd64 consumer path does not download. RC3 already fixes that path by verifying only selected assets and enforcing attestations. The canary should exercise the release candidate currently graduating rather than repeatedly fail before VM validation on the superseded stable pin.

## Impact

This changes only release-evidence CI. It does not change supported runtime behavior and does not reset the four-campaign graduation window.

## Validation

- git diff --check
- verified annotated v0.4.0-rc.3 peels to cba1e09537f2e05e4ba7278efdb5c2d044d1889b
- verified the GitHub release is a published prerelease

After merge, manually dispatch consumer-canary and require both prebuilt and source-build jobs to pass.
