### PR TITLE
ci: stop queueing unavailable self-hosted gate

### DIFF
--- a/.github/workflows/bpfcompat-example.yml
+++ b/.github/workflows/bpfcompat-example.yml
@@ -1,20 +1,11 @@
 name: bpfcompat-example
 
+# Optional operator lane for environments that register a Linux x64 runner
+# with KVM. Pull requests use bpfcompat-example-hosted instead; keeping this
+# workflow manual prevents permanently queued jobs when no self-hosted runner
+# is registered.
 on:
   workflow_dispatch:
-  pull_request:
-    paths:
-      - "cmd/**"
-      - "internal/**"
-      - "validator/**"
-      - "examples/**"
-      - "matrices/**"
-      - "vm/**"
-      - "action.yml"
-      - "Makefile"
-      - "go.mod"
-      - "go.sum"
-      - ".github/workflows/bpfcompat-example.yml"
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

Stops automatically queueing the optional self-hosted compatibility workflow on pull requests.

The repository currently has zero registered self-hosted runners, so every compatibility-relevant PR receives a `Compatibility Gate` job that can never start. The required `Compatibility Gate (hosted runner)` already runs the same QEMU/KVM validation on GitHub-hosted infrastructure and remains enforced by branch protection.

The self-hosted workflow remains available through `workflow_dispatch` for operators that later register a suitable Linux x64 KVM runner.

No tracking issue is required.

## Security and release impact

- no required status check is removed
- hosted KVM validation remains required
- no CLI, Action, profile, or validation behavior changes
- release-tooling-only; does not reset the v0.4 campaign window

## Validation

- `go run github.com/rhysd/actionlint/cmd/actionlint@v1.7.11`
- `go test ./...`
- `git diff --check`