### PR TITLE
feat(diff): compare two evidence reports and report only NEW regressions

### DIFF
--- a/cmd/bpfcompat/diff.go
+++ b/cmd/bpfcompat/diff.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"os"
@@ -36,6 +37,10 @@ func runDiff(args []string) int {
 		fs.PrintDefaults()
 	}
 	if err := fs.Parse(args); err != nil {
+		// --help is a successful request for help, not a failed comparison.
+		if errors.Is(err, flag.ErrHelp) {
+			return 0
+		}
 		return regressiondiff.ExitInconclusive
 	}
 
@@ -67,7 +72,12 @@ func runDiff(args []string) int {
 	if strings.TrimSpace(*markdownPath) != "" {
 		fmt.Printf("Diff Markdown: %s\n", *markdownPath)
 	}
-	if strings.TrimSpace(*outPath) == "" && strings.TrimSpace(*markdownPath) == "" {
+	// With no output file selected the diff itself is written to stdout, and
+	// stdout has to stay machine-readable: the flag help promises JSON there,
+	// and `bpfcompat diff ... | jq` must work. The human summary then goes to
+	// stderr rather than being appended after the JSON document.
+	jsonOnStdout := strings.TrimSpace(*outPath) == "" && strings.TrimSpace(*markdownPath) == ""
+	if jsonOnStdout {
 		enc := json.NewEncoder(os.Stdout)
 		enc.SetIndent("", "  ")
 		if err := enc.Encode(d); err != nil {
@@ -76,11 +86,15 @@ func runDiff(args []string) int {
 		}
 	}
 
+	summaryOut := os.Stdout
+	if jsonOnStdout {
+		summaryOut = os.Stderr
+	}
 	s := d.Summary
-	fmt.Printf("Result: %s\n", s.Result)
-	fmt.Printf("New required regressions: %d | new optional: %d | existing incompatibilities: %d | fixed: %d | unchanged: %d\n",
+	fmt.Fprintf(summaryOut, "Result: %s\n", s.Result)
+	fmt.Fprintf(summaryOut, "New required regressions: %d | new optional: %d | existing incompatibilities: %d | fixed: %d | unchanged: %d\n",
 		s.NewRequiredRegressions, s.NewOptionalRegressions, s.ExistingIncompatibility, s.Fixed, s.UnchangedCompatible)
-	fmt.Printf("Inconclusive required: %d | optional: %d | coverage added: %d | removed required: %d | removed optional: %d\n",
+	fmt.Fprintf(summaryOut, "Inconclusive required: %d | optional: %d | coverage added: %d | removed required: %d | removed optional: %d\n",
 		s.InconclusiveRequired, s.InconclusiveOptional, s.CoverageAddedCount, s.CoverageRemovedRequired, s.CoverageRemovedOptional)
 
 	return regressiondiff.ExitCode(d)

--- a/cmd/bpfcompat/diff.go
+++ b/cmd/bpfcompat/diff.go
@@ -6,6 +6,7 @@ import (
 	"flag"
 	"fmt"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 
@@ -47,6 +48,14 @@ func runDiff(args []string) int {
 	if strings.TrimSpace(*baseline) == "" || strings.TrimSpace(*candidate) == "" {
 		fmt.Fprintln(os.Stderr, "diff requires --baseline and --candidate")
 		fs.Usage()
+		return regressiondiff.ExitInconclusive
+	}
+
+	// One file cannot be both outputs: whichever is written second wins, so a
+	// consumer parsing --out would silently receive Markdown. Caught before
+	// anything runs, because the fix is the command line, not the evidence.
+	if err := distinctOutputs(*outPath, *markdownPath); err != nil {
+		fmt.Fprintf(os.Stderr, "diff failed: %v\n", err)
 		return regressiondiff.ExitInconclusive
 	}
 
@@ -98,4 +107,24 @@ func runDiff(args []string) int {
 		s.InconclusiveRequired, s.InconclusiveOptional, s.CoverageAddedCount, s.CoverageRemovedRequired, s.CoverageRemovedOptional)
 
 	return regressiondiff.ExitCode(d)
+}
+
+// distinctOutputs refuses --out and --markdown pointing at one file.
+func distinctOutputs(outPath, markdownPath string) error {
+	out, markdown := strings.TrimSpace(outPath), strings.TrimSpace(markdownPath)
+	if out == "" || markdown == "" {
+		return nil
+	}
+	outAbs, err := filepath.Abs(out)
+	if err != nil {
+		return fmt.Errorf("resolve --out: %w", err)
+	}
+	markdownAbs, err := filepath.Abs(markdown)
+	if err != nil {
+		return fmt.Errorf("resolve --markdown: %w", err)
+	}
+	if outAbs == markdownAbs {
+		return fmt.Errorf("--out and --markdown are the same file (%s); the Markdown would overwrite the JSON evidence", outAbs)
+	}
+	return nil
 }

--- a/cmd/bpfcompat/diff.go
+++ b/cmd/bpfcompat/diff.go
@@ -6,7 +6,6 @@ import (
 	"flag"
 	"fmt"
 	"os"
-	"path/filepath"
 	"strings"
 	"time"
 
@@ -115,16 +114,10 @@ func distinctOutputs(outPath, markdownPath string) error {
 	if out == "" || markdown == "" {
 		return nil
 	}
-	outAbs, err := filepath.Abs(out)
-	if err != nil {
-		return fmt.Errorf("resolve --out: %w", err)
-	}
-	markdownAbs, err := filepath.Abs(markdown)
-	if err != nil {
-		return fmt.Errorf("resolve --markdown: %w", err)
-	}
-	if outAbs == markdownAbs {
-		return fmt.Errorf("--out and --markdown are the same file (%s); the Markdown would overwrite the JSON evidence", outAbs)
+	// Compared by file identity, not by path text: a link or a second route to
+	// the same directory is the same file, however differently it is spelled.
+	if regressiondiff.SameFile(out, markdown) {
+		return fmt.Errorf("--out and --markdown are the same file (%s); the Markdown would overwrite the JSON evidence", out)
 	}
 	return nil
 }

--- a/cmd/bpfcompat/diff.go
+++ b/cmd/bpfcompat/diff.go
@@ -1,0 +1,87 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/kernel-guard/bpfcompat/internal/regressiondiff"
+)
+
+// runDiff compares two evidence reports and answers one question: did this
+// candidate break an environment the baseline supported?
+//
+// It is deliberately a new subcommand rather than a change to `compare`.
+// `compare` predates the Gate 1 verdict contract, ranks statuses ordinally, and
+// is consumed by the frozen experimental API; changing its meaning would break
+// an existing surface to improve a different one.
+func runDiff(args []string) int {
+	fs := flag.NewFlagSet("diff", flag.ContinueOnError)
+	baseline := fs.String("baseline", "", "Path to the baseline (reference release) compatibility report JSON")
+	candidate := fs.String("candidate", "", "Path to the candidate (release under evaluation) compatibility report JSON")
+	outPath := fs.String("out", "", "Path to write the diff JSON (optional; printed to stdout when neither --out nor --markdown is set)")
+	markdownPath := fs.String("markdown", "", "Path to write the diff Markdown (optional)")
+	fs.Usage = func() {
+		fmt.Fprintf(fs.Output(), "Usage:\n  bpfcompat diff --baseline <report.json> --candidate <report.json> [flags]\n\n")
+		fmt.Fprintf(fs.Output(), "Compares two bpfcompat evidence reports and reports only NEW compatibility\n")
+		fmt.Fprintf(fs.Output(), "regressions, separately from known limitations, fixes and coverage changes.\n")
+		fmt.Fprintf(fs.Output(), "Offline and stateless: it reads the two files and nothing else.\n\n")
+		fmt.Fprintf(fs.Output(), "Exit codes:\n")
+		fmt.Fprintf(fs.Output(), "  0  no new required regression; every required comparison was established\n")
+		fmt.Fprintf(fs.Output(), "  1  the required comparison could not be established (not a claim about the candidate)\n")
+		fmt.Fprintf(fs.Output(), "  2  a required environment the baseline supported is broken in the candidate\n\n")
+		fs.PrintDefaults()
+	}
+	if err := fs.Parse(args); err != nil {
+		return regressiondiff.ExitInconclusive
+	}
+
+	if strings.TrimSpace(*baseline) == "" || strings.TrimSpace(*candidate) == "" {
+		fmt.Fprintln(os.Stderr, "diff requires --baseline and --candidate")
+		fs.Usage()
+		return regressiondiff.ExitInconclusive
+	}
+
+	d, err := regressiondiff.Compare(*baseline, *candidate, time.Now())
+	if err != nil {
+		// Unreadable, unparseable or unknown-schema evidence is an inability to
+		// compare, never a verdict on the candidate.
+		fmt.Fprintf(os.Stderr, "diff failed: %v\n", err)
+		return regressiondiff.ExitInconclusive
+	}
+
+	if err := regressiondiff.WriteJSON(*outPath, d); err != nil {
+		fmt.Fprintf(os.Stderr, "write diff JSON: %v\n", err)
+		return regressiondiff.ExitInconclusive
+	}
+	if strings.TrimSpace(*outPath) != "" {
+		fmt.Printf("Diff JSON: %s\n", *outPath)
+	}
+	if err := regressiondiff.WriteMarkdown(*markdownPath, d); err != nil {
+		fmt.Fprintf(os.Stderr, "write diff Markdown: %v\n", err)
+		return regressiondiff.ExitInconclusive
+	}
+	if strings.TrimSpace(*markdownPath) != "" {
+		fmt.Printf("Diff Markdown: %s\n", *markdownPath)
+	}
+	if strings.TrimSpace(*outPath) == "" && strings.TrimSpace(*markdownPath) == "" {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(d); err != nil {
+			fmt.Fprintf(os.Stderr, "encode diff JSON: %v\n", err)
+			return regressiondiff.ExitInconclusive
+		}
+	}
+
+	s := d.Summary
+	fmt.Printf("Result: %s\n", s.Result)
+	fmt.Printf("New required regressions: %d | new optional: %d | existing incompatibilities: %d | fixed: %d | unchanged: %d\n",
+		s.NewRequiredRegressions, s.NewOptionalRegressions, s.ExistingIncompatibility, s.Fixed, s.UnchangedCompatible)
+	fmt.Printf("Inconclusive required: %d | optional: %d | coverage added: %d | removed required: %d | removed optional: %d\n",
+		s.InconclusiveRequired, s.InconclusiveOptional, s.CoverageAddedCount, s.CoverageRemovedRequired, s.CoverageRemovedOptional)
+
+	return regressiondiff.ExitCode(d)
+}

--- a/cmd/bpfcompat/main.go
+++ b/cmd/bpfcompat/main.go
@@ -47,6 +47,8 @@ func run(args []string) int {
 		return runHistory(args[1:])
 	case "compare":
 		return runCompare(args[1:])
+	case "diff":
+		return runDiff(args[1:])
 	case "serve":
 		return runServe(args[1:])
 	case "runtime":
@@ -1439,6 +1441,7 @@ func printRootUsage() {
 	fmt.Println("  bpfcompat history sign [flags]")
 	fmt.Println("  bpfcompat compare --base-report <file> --head-report <file> [flags]")
 	fmt.Println("  bpfcompat compare --artifact-name <name> --base-version <v1> --head-version <v2> [flags]")
+	fmt.Println("  bpfcompat diff --baseline <report.json> --candidate <report.json> [flags]")
 	fmt.Println("  bpfcompat serve [flags]")
 	fmt.Println("  bpfcompat runtime probe [flags]")
 	fmt.Println("  bpfcompat runtime select --artifact-name <name> [flags]")

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -108,6 +108,7 @@ tooling.
 ## Next
 
 - [compatibility-contract.md](compatibility-contract.md) — what a bpfcompat result means: artifact, loader, environment, verdict, and CI exit semantics
+- [release-regression-diff.md](release-regression-diff.md) — `bpfcompat diff`: compare a candidate release against a baseline and gate on *new* regressions only
 - [evidence-schema.md](evidence-schema.md) — the report format + classification taxonomy
 - [verifying-releases.md](verifying-releases.md) — verify signed, attested binaries
 - [case-study-falco-modern-bpf.md](case-study-falco-modern-bpf.md) — a real reference matrix

--- a/docs/release-regression-diff.md
+++ b/docs/release-regression-diff.md
@@ -1,0 +1,163 @@
+# Release Regression Diff
+
+`bpfcompat diff` compares two compatibility reports and answers one question:
+
+> Did this candidate release break an environment my previous release supported?
+
+An absolute compatibility matrix cannot answer that. A release that has always
+failed on 4.14 looks identical to one that broke 4.14 yesterday — both are red.
+The diff separates the two.
+
+It is **offline and stateless**: it reads two JSON files and nothing else. No
+database, no history store, no network, no service.
+
+```
+bpfcompat diff --baseline release-1.2.json --candidate release-1.3.json \
+  --out diff.json --markdown diff.md
+```
+
+## Baseline and candidate
+
+**Baseline** is trusted reference evidence — the compatibility report of a
+release you already shipped and support. **Candidate** is the release being
+evaluated.
+
+Both must be bpfcompat reports with `schema_version: v0.1`. Anything else is
+refused rather than guessed at.
+
+## What gets compared
+
+The comparison unit is a **support obligation**: one environment your matrix
+promises to validate. Its key is the **`profile_id`**.
+
+Deliberately *not* part of the key:
+
+- **the artifact SHA-256** — release N and N+1 are supposed to contain different
+  artifacts. Both are recorded for traceability, never for matching.
+- **the observed kernel** — Gate 1 separates the environment that was *requested*
+  from the one that actually *booted*. The obligation is the requested one.
+
+Two guards protect the key from matching things that only look alike:
+
+- if the same `profile_id` requests a different kernel family on each side, the
+  obligation itself changed and the cell is inconclusive;
+- if one report was produced by the generic validator and the other by a
+  project's own loader (command mode), the loader contract changed and every
+  cell is inconclusive. "Did it regress" has no meaning when the thing doing the
+  loading also changed.
+
+## Classifications
+
+| Classification | Baseline → Candidate | Meaning |
+|---|---|---|
+| `UNCHANGED_COMPATIBLE` | COMPATIBLE → COMPATIBLE | supported before, supported now |
+| `NEW_REGRESSION` | COMPATIBLE → INCOMPATIBLE | **the product signal.** This release broke an environment the baseline proved worked |
+| `EXISTING_INCOMPATIBILITY` | INCOMPATIBLE → INCOMPATIBLE | a known limitation. Still visible, but not newly introduced |
+| `FIXED` | INCOMPATIBLE → COMPATIBLE | the candidate gained support |
+| `INCONCLUSIVE` | either side unproven | the change cannot be established |
+| `COVERAGE_ADDED` | absent → present | the candidate tests something new. Not a regression |
+| `COVERAGE_REMOVED` | present → absent | continued support cannot be established. Not the same as broken |
+
+`NEW_REGRESSION` is the only classification that is a statement about the
+candidate's software.
+
+### When a comparison is inconclusive
+
+A cell is inconclusive when either side failed to settle the question:
+
+- `INFRA_ERROR` or `UNSUPPORTED` on either side;
+- either side ran a kernel other than the one the profile names
+  (`environment.kernel_family_match: false`);
+- no verdict recorded, or a verdict this differ does not recognise;
+- the obligation or loader contract changed between the reports.
+
+**An unproven baseline can never manufacture a regression.** If the baseline hit
+an infrastructure failure and the candidate is incompatible, that is
+`INCONCLUSIVE`, not `NEW_REGRESSION` — the baseline never proved the environment
+worked, so nothing can be said to have broken. The candidate's incompatibility
+stays visible in the cell as evidence.
+
+## Required versus optional
+
+Gate 1 established that `required: false` is informational and does not gate a
+release. The diff preserves that exactly:
+
+- a **required** `NEW_REGRESSION` blocks the candidate;
+- an **optional** `NEW_REGRESSION` is reported prominently and counted
+  separately, but does not gate;
+- a **required** `INCONCLUSIVE` or `COVERAGE_REMOVED` prevents a green result —
+  the candidate's compatibility relative to the baseline was not established;
+- an **optional** one is visible and non-gating.
+
+Which side decides: the **candidate's** `required` flag, because the candidate
+defines the release's current support claims. When the candidate dropped the
+obligation entirely, the baseline's flag is used — that is what was lost. A
+`required` → `optional` demotion is recorded as `required_changed: true` so
+downgrading a profile to dodge a gate is visible in the evidence.
+
+## Coverage completeness
+
+`summary.baseline_complete` and `summary.candidate_complete` carry Gate 1's
+run-level coverage flag straight through. A diff built from incomplete evidence
+is a weaker claim than it looks, and both the JSON summary and the top of the
+Markdown say so. `COMPATIBLE + complete:false` is never treated as equivalent to
+`COMPATIBLE + complete:true`.
+
+## CI exit semantics
+
+| Exit | Result | What a CI consumer should conclude |
+|---:|---|---|
+| `0` | `NO_NEW_REGRESSIONS` | No required environment regressed, and every required comparison was established. Known limitations may remain; optional regressions may be present and are reported. |
+| `2` | `NEW_REGRESSIONS` | A required environment the baseline supported is broken in the candidate. **Do not ship.** |
+| `1` | `INCONCLUSIVE` | The required comparison could not be established — infrastructure failure, an environment mismatch, removed required coverage, missing, malformed or unsupported evidence. **This is not a claim that the candidate is incompatible.** |
+
+Exit `2` outranks exit `1`: a proven regression is a definitive fact about the
+candidate and must not be buried by an inability to compare somewhere else.
+
+## Output
+
+`diff.json` is the machine-readable evidence, versioned
+`bpfcompat.regression-diff.v0.1` — distinct from the run-report schema because
+the semantics are different. The Markdown is rendered from it and is
+presentation only; never parse it.
+
+Each cell records both sides' verdict, required flag, classification code,
+requested and observed kernel, whether the environment was established, the
+classification and a plain-language reason.
+
+## Minimal example
+
+```
+$ bpfcompat diff --baseline v1.2.json --candidate v1.3.json
+Result: NEW_REGRESSIONS
+New required regressions: 1 | new optional: 0 | existing incompatibilities: 0 | fixed: 0 | unchanged: 1
+$ echo $?
+2
+```
+
+```json
+{
+  "schema_version": "bpfcompat.regression-diff.v0.1",
+  "cells": [{
+    "key": "ubuntu-20.04-5.4",
+    "required": true,
+    "classification": "NEW_REGRESSION",
+    "reason": "the baseline proved this environment worked and the candidate proves it no longer does",
+    "baseline":  {"verdict": "COMPATIBLE",   "environment_established": true},
+    "candidate": {"verdict": "INCOMPATIBLE", "classification_code": "UNSUPPORTED_MAP_TYPE",
+                  "environment_established": true}
+  }],
+  "summary": {"new_required_regressions": 1, "result": "NEW_REGRESSIONS"}
+}
+```
+
+## Scope
+
+The diff consumes evidence; it does not produce it. It never re-runs a program,
+never parses a loader's stderr to decide compatibility, and never infers a
+kernel capability. Every verdict it reports was recorded by the run that
+produced the report — see
+[compatibility-contract.md](compatibility-contract.md).
+
+Storing evidence over time is not part of this command. Point it at two files
+you already have.

--- a/docs/release-regression-diff.md
+++ b/docs/release-regression-diff.md
@@ -37,14 +37,40 @@ Deliberately *not* part of the key:
 - **the observed kernel** — Gate 1 separates the environment that was *requested*
   from the one that actually *booted*. The obligation is the requested one.
 
-Two guards protect the key from matching things that only look alike:
+Guards protect the key from matching things that only look alike. A
+`profile_id` is a name, and a name can be pointed at a different promise:
 
-- if the same `profile_id` requests a different kernel family on each side, the
-  obligation itself changed and the cell is inconclusive;
+- if the same `profile_id` requests a different **kernel family**,
+  **architecture**, **distro** or **distro version** on each side, the
+  obligation itself changed and the cell is inconclusive. `ubuntu-22.04-5.15`
+  validated on x86_64 at baseline and on arm64 in the candidate is not one
+  obligation with a changed result — it is two obligations sharing a name;
+- if the two sides exercised **different amounts of the contract** (different
+  `validation.attach_mode`), the cell is inconclusive. A load-only candidate
+  cannot inherit an attach-tested baseline's green;
 - if one report was produced by the generic validator and the other by a
   project's own loader (command mode), the loader contract changed and every
   cell is inconclusive. "Did it regress" has no meaning when the thing doing the
-  loading also changed.
+  loading also changed;
+- in command mode, if the **command under test** (`invocation_sha256`) or the
+  **exit code that counts as success** changed, every cell is inconclusive: the
+  two runs answer different questions.
+
+### What is allowed to change
+
+Deliberately *not* guarded, because these are supposed to change between
+releases:
+
+- the **artifact** SHA-256 and OCI digest — that is the point of the comparison;
+- in command mode, the **project's own loader binary** (`command.binary.sha256`).
+  It *is* the thing being released. Requiring it to be byte-identical between
+  release N and N+1 would make every real comparison incomparable;
+- the **bpfcompat validator build** (`validator.sha256`) in artifact mode. It is
+  the measuring instrument, not the subject, and its load/attach contract is
+  stable across bpfcompat versions by design. A change is recorded as a **note**
+  in the diff, because it is the first thing to check when a result surprises
+  you — but it does not gate, since gating on it would make every bpfcompat
+  upgrade report every environment as incomparable.
 
 ## Classifications
 
@@ -67,10 +93,40 @@ A cell is inconclusive when either side failed to settle the question:
 
 - `INFRA_ERROR` or `UNSUPPORTED` on either side;
 - either side ran a kernel other than the one the profile names
-  (`environment.kernel_family_match: false`);
+  (`environment.kernel_family_match: false`) — recorded as
+  `environment_evidence: "mismatch"`;
+- either side **never recorded which kernel it ran** (no `environment`, or no
+  `environment.kernel_family_match`) — recorded as
+  `environment_evidence: "unknown"`;
 - no verdict recorded, or a verdict this differ does not recognise;
-- the obligation, its requiredness, or the loader contract changed between the
-  reports.
+- the obligation, its requiredness, the validation depth, or the loader contract
+  changed between the reports;
+- the candidate added a required obligation but did not establish it — a new row
+  with no evidence in it is not added coverage.
+
+`unknown` and `mismatch` are kept apart on purpose. A report that never named a
+kernel is not evidence that the wrong kernel booted, and the reason text never
+claims it is.
+
+### Why "unknown" is not "established"
+
+`schema.EstablishedRequestedEnvironment` — the Gate 1 helper — answers **true**
+when the environment metadata is absent. That is correct where it is used: a
+report reader must not invent a failure out of a field an older bpfcompat never
+wrote, and blaming a user's software for our missing metadata would be worse
+than saying nothing.
+
+A release gate asks a different question: *do we positively know this candidate
+still supports the environment we promise?* "The file does not say" is not a
+yes. So `internal/regressiondiff` applies its **own, stricter** reading and
+treats absent environment evidence as unknown. The shared helper is deliberately
+left alone — changing it would silently restate the contract of every existing
+consumer.
+
+The practical consequence: a **pre-Gate-1 report can be read but can never be
+conclusive.** It is not rejected — age is not tampering — but it cannot prove a
+baseline was COMPATIBLE, so it can neither manufacture a `NEW_REGRESSION` nor
+support an `UNCHANGED_COMPATIBLE`.
 
 ## Evidence that cannot be compared at all
 
@@ -84,9 +140,47 @@ comparison keys cannot be trusted. Each produces exit `1` with an explanation:
   obligation is ambiguous, and a release gate may not resolve that by guessing;
 - unreadable, malformed, or unsupported-schema evidence, **including a file
   carrying anything after the report** — a truncated or concatenated file would
-  otherwise be compared from its first JSON value alone.
+  otherwise be compared from its first JSON value alone;
+- a **duplicated JSON key** anywhere in the document. `encoding/json` accepts
+  duplicates and keeps the last value, so
+  `"verdict":"INCOMPATIBLE","verdict":"COMPATIBLE"` parses green while a human
+  reading the file sees a failure. Which value a release decision came from must
+  not depend on a parser's choice;
+- a target that **does not state `required`** (absent, or `null`). It
+  deserializes to `false`, which would silently demote a proven regression to a
+  non-gating optional finding. Deleting the field is not a way to discover that
+  an obligation was never required;
+- a target whose **`status` and `verdict` contradict each other** — the runner
+  derives one from the other, so genuine evidence always agrees. A report does
+  not become conclusive because one of its fields contains the word
+  `COMPATIBLE`;
+- a target asserting **`kernel_family_match` without** the requested family and
+  observed kernel it would have been derived from — the claim rests on nothing;
+- a report whose **`summary` contradicts its own targets** (`summary.verdict`
+  against the required targets, `summary.complete` against the coverage,
+  `summary.status` against `summary.verdict`). The targets are the single source
+  of semantic truth; a file that disagrees with itself is not trustworthy in
+  either direction, and refusing is better than resolving the conflict *as*
+  `INCOMPATIBLE`, which would blame a candidate for a broken input file;
+- **the same run on both sides** — identical `run.id`, or literally the same
+  file. It is trivially, permanently green: it proves a run equals itself and
+  nothing about a candidate release. The usual cause is CI wiring that fetched
+  the same artifact twice, and a gate a wiring mistake can satisfy protects
+  nothing;
+- a file **larger than 32 MiB**. Real reports are kilobytes; the largest this
+  project has produced is ~60 KB. The bound exists because this command is
+  designed to eat CI artifacts a pull-request author controls, and reading an
+  attacker-sized file into memory before validating it is an OOM, not a gate.
 
-None of these is a statement about the candidate's software.
+None of these is a statement about the candidate's software. Every one is exit
+`1`.
+
+### The comparison never destroys its inputs
+
+`--out` and `--markdown` refuse to write over the baseline or candidate report,
+and refuse to be the same file as each other. The baseline is the record of what
+your last release supported; it may be the only copy, and `--out "$BASELINE"` is
+one unset variable away in any CI script.
 
 **An unproven baseline can never manufacture a regression.** If the baseline hit
 an infrastructure failure and the candidate is incompatible, that is

--- a/docs/release-regression-diff.md
+++ b/docs/release-regression-diff.md
@@ -82,7 +82,9 @@ comparison keys cannot be trusted. Each produces exit `1` with an explanation:
   unidentifiable;
 - a **duplicated `profile_id`** within one report — which result represents that
   obligation is ambiguous, and a release gate may not resolve that by guessing;
-- unreadable, malformed, or unsupported-schema evidence.
+- unreadable, malformed, or unsupported-schema evidence, **including a file
+  carrying anything after the report** — a truncated or concatenated file would
+  otherwise be compared from its first JSON value alone.
 
 None of these is a statement about the candidate's software.
 
@@ -141,6 +143,10 @@ candidate and must not be buried by an inability to compare somewhere else.
 `bpfcompat.regression-diff.v0.1` — distinct from the run-report schema because
 the semantics are different. The Markdown is rendered from it and is
 presentation only; never parse it.
+
+With neither `--out` nor `--markdown` set, the diff JSON is written to **stdout**
+and stays parseable (`bpfcompat diff ... | jq` works); the human-readable summary
+goes to stderr. With an output file selected, the summary goes to stdout.
 
 Each cell records both sides' verdict, required flag, classification code,
 requested and observed kernel, whether the environment was established, the

--- a/docs/release-regression-diff.md
+++ b/docs/release-regression-diff.md
@@ -182,6 +182,10 @@ and refuse to be the same file as each other. The baseline is the record of what
 your last release supported; it may be the only copy, and `--out "$BASELINE"` is
 one unset variable away in any CI script.
 
+The comparison is by **file identity**, not by path text: a symbolic link, a
+hard link, or a second route to the same directory is the same file however
+differently it is spelled.
+
 **An unproven baseline can never manufacture a regression.** If the baseline hit
 an infrastructure failure and the candidate is incompatible, that is
 `INCONCLUSIVE`, not `NEW_REGRESSION` — the baseline never proved the environment

--- a/docs/release-regression-diff.md
+++ b/docs/release-regression-diff.md
@@ -69,7 +69,22 @@ A cell is inconclusive when either side failed to settle the question:
 - either side ran a kernel other than the one the profile names
   (`environment.kernel_family_match: false`);
 - no verdict recorded, or a verdict this differ does not recognise;
-- the obligation or loader contract changed between the reports.
+- the obligation, its requiredness, or the loader contract changed between the
+  reports.
+
+## Evidence that cannot be compared at all
+
+Some inputs are rejected outright, before any cell is built, because their
+comparison keys cannot be trusted. Each produces exit `1` with an explanation:
+
+- a report with **no targets** — it establishes nothing to compare against;
+- a target with an **empty `profile_id`** — the obligation it represents is
+  unidentifiable;
+- a **duplicated `profile_id`** within one report — which result represents that
+  obligation is ambiguous, and a release gate may not resolve that by guessing;
+- unreadable, malformed, or unsupported-schema evidence.
+
+None of these is a statement about the candidate's software.
 
 **An unproven baseline can never manufacture a regression.** If the baseline hit
 an infrastructure failure and the candidate is incompatible, that is
@@ -89,11 +104,17 @@ release. The diff preserves that exactly:
   the candidate's compatibility relative to the baseline was not established;
 - an **optional** one is visible and non-gating.
 
-Which side decides: the **candidate's** `required` flag, because the candidate
-defines the release's current support claims. When the candidate dropped the
-obligation entirely, the baseline's flag is used — that is what was lost. A
-`required` → `optional` demotion is recorded as `required_changed: true` so
-downgrading a profile to dodge a gate is visible in the evidence.
+Which side decides: **either**. A cell gates if the baseline *or* the candidate
+treated the obligation as required. Letting the candidate alone decide was a
+hole — a release could flip a profile to `required: false` and turn a regression
+on an environment the baseline promised into a non-gating optional finding.
+
+A change in requiredness is a change to the **support contract**, not to the
+software, so such a cell is `INCONCLUSIVE` and `required_changed: true` is
+recorded. Whether a candidate regressed against a promise that did not exist at
+baseline — or still honours one it has since dropped — is not something this
+evidence can settle, in either direction, so neither direction is reasoned about
+asymmetrically.
 
 ## Coverage completeness
 

--- a/internal/regressiondiff/diff.go
+++ b/internal/regressiondiff/diff.go
@@ -1,0 +1,455 @@
+// Package regressiondiff compares two bpfcompat evidence reports and reports
+// how the compatibility evidence changed between them.
+//
+// It answers exactly one question: "did this candidate break an environment my
+// baseline supported?" It is not a second compatibility classifier. It never
+// re-reads validator logs, never re-runs anything, and never infers a verdict
+// of its own -- it consumes the structured verdict, environment and
+// completeness fields the run itself recorded.
+//
+// The separate internal/compare package predates the Gate 1 verdict contract
+// and ranks statuses ordinally (pass 3 > fail 2 > infra_error 1). That makes a
+// VM which failed to boot read as a regression, and makes a genuine
+// incompatibility appearing where there was an infra error read as an
+// improvement. It is still used by the frozen experimental API and is left
+// alone; nothing here builds on it.
+package regressiondiff
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+
+	"github.com/kernel-guard/bpfcompat/pkg/schema"
+)
+
+// SchemaVersion identifies the diff evidence format. Deliberately distinct from
+// the run-report schema: the semantics are different, so reusing v0.1 would let
+// a consumer parse one as the other.
+const SchemaVersion = "bpfcompat.regression-diff.v0.1"
+
+// supportedReportSchema is the only run-report schema this differ understands.
+// Comparing structures whose semantics are unknown is worse than refusing.
+const supportedReportSchema = "v0.1"
+
+// Cell classifications. Kept deliberately small: each state exists because a
+// release decision differs for it.
+const (
+	// UnchangedCompatible: supported before, supported now.
+	UnchangedCompatible = "UNCHANGED_COMPATIBLE"
+
+	// NewRegression: the baseline proved this environment worked and the
+	// candidate proves it no longer does. The primary product signal, and the
+	// only classification that is a statement about the candidate's software.
+	NewRegression = "NEW_REGRESSION"
+
+	// ExistingIncompatibility: broken before, broken now. A known limitation --
+	// it must stay visible, but shipping it again is not a new regression.
+	ExistingIncompatibility = "EXISTING_INCOMPATIBILITY"
+
+	// Fixed: broken before, working now.
+	Fixed = "FIXED"
+
+	// Inconclusive: at least one side never established the compatibility of
+	// this obligation, so the change cannot be known. Never upgraded to
+	// NewRegression on suspicion.
+	Inconclusive = "INCONCLUSIVE"
+
+	// CoverageAdded: the candidate tests an obligation the baseline did not.
+	// New evidence, not a regression.
+	CoverageAdded = "COVERAGE_ADDED"
+
+	// CoverageRemoved: the baseline tested an obligation the candidate does
+	// not. Continued support cannot be established -- which is not the same as
+	// the software being broken.
+	CoverageRemoved = "COVERAGE_REMOVED"
+)
+
+// Overall results, mapped to exit codes by the caller.
+const (
+	ResultNoRegressions = "NO_NEW_REGRESSIONS"
+	ResultRegressed     = "NEW_REGRESSIONS"
+	ResultInconclusive  = "INCONCLUSIVE"
+)
+
+type ReportRef struct {
+	Path          string `json:"path"`
+	RunID         string `json:"run_id,omitempty"`
+	SchemaVersion string `json:"schema_version,omitempty"`
+	Verdict       string `json:"verdict,omitempty"`
+	Complete      *bool  `json:"complete,omitempty"`
+	// ArtifactSHA256 and the OCI fields are traceability only. They are
+	// deliberately NOT part of the comparison key: release N and N+1 are
+	// supposed to contain different artifacts.
+	ArtifactSHA256 string `json:"artifact_sha256,omitempty"`
+	ArtifactSource string `json:"artifact_source,omitempty"`
+	ArtifactDigest string `json:"artifact_source_digest,omitempty"`
+	LoaderMode     string `json:"loader_mode,omitempty"`
+	LoaderSHA256   string `json:"loader_sha256,omitempty"`
+}
+
+// CellSide is one side's evidence for a single obligation.
+type CellSide struct {
+	Present               bool   `json:"present"`
+	Verdict               string `json:"verdict,omitempty"`
+	Status                string `json:"status,omitempty"`
+	Required              bool   `json:"required,omitempty"`
+	ClassificationCode    string `json:"classification_code,omitempty"`
+	RequestedKernelFamily string `json:"requested_kernel_family,omitempty"`
+	ObservedKernel        string `json:"observed_kernel,omitempty"`
+	KernelFamilyMatch     *bool  `json:"kernel_family_match,omitempty"`
+	// EnvironmentEstablished is false when this side ran, but not on the
+	// environment the obligation names.
+	EnvironmentEstablished bool `json:"environment_established"`
+}
+
+type Cell struct {
+	Key             string   `json:"key"`
+	ProfileID       string   `json:"profile_id"`
+	Required        bool     `json:"required"`
+	RequiredChanged bool     `json:"required_changed,omitempty"`
+	Classification  string   `json:"classification"`
+	Reason          string   `json:"reason"`
+	Baseline        CellSide `json:"baseline"`
+	Candidate       CellSide `json:"candidate"`
+}
+
+type Summary struct {
+	TotalCells              int `json:"total_cells"`
+	NewRequiredRegressions  int `json:"new_required_regressions"`
+	NewOptionalRegressions  int `json:"new_optional_regressions"`
+	ExistingIncompatibility int `json:"existing_incompatibilities"`
+	Fixed                   int `json:"fixed"`
+	UnchangedCompatible     int `json:"unchanged_compatible"`
+	InconclusiveRequired    int `json:"inconclusive_required"`
+	InconclusiveOptional    int `json:"inconclusive_optional"`
+	CoverageAddedCount      int `json:"coverage_added"`
+	CoverageRemovedRequired int `json:"coverage_removed_required"`
+	CoverageRemovedOptional int `json:"coverage_removed_optional"`
+	// BaselineComplete/CandidateComplete surface Gate 1's run-level coverage
+	// flag, so an incomplete input cannot be read as a full comparison.
+	BaselineComplete  *bool  `json:"baseline_complete,omitempty"`
+	CandidateComplete *bool  `json:"candidate_complete,omitempty"`
+	Result            string `json:"result"`
+}
+
+type Diff struct {
+	SchemaVersion string    `json:"schema_version"`
+	GeneratedAt   string    `json:"generated_at"`
+	Baseline      ReportRef `json:"baseline"`
+	Candidate     ReportRef `json:"candidate"`
+	Summary       Summary   `json:"summary"`
+	Cells         []Cell    `json:"cells"`
+	Notes         []string  `json:"notes,omitempty"`
+}
+
+// UnsupportedSchemaError is returned when a report's schema is not one this
+// differ understands. Comparing it anyway would guess at semantics.
+type UnsupportedSchemaError struct {
+	Side, Got, Want string
+}
+
+func (e *UnsupportedSchemaError) Error() string {
+	return fmt.Sprintf("%s report schema_version %q is not supported (this differ understands %q); refusing to compare structures whose semantics are unknown",
+		e.Side, e.Got, e.Want)
+}
+
+// CheckSchemas fails closed on anything this differ does not understand.
+func CheckSchemas(baseline, candidate schema.ReportV01) error {
+	for _, s := range []struct {
+		side string
+		got  string
+	}{{"baseline", baseline.SchemaVersion}, {"candidate", candidate.SchemaVersion}} {
+		if strings.TrimSpace(s.got) != supportedReportSchema {
+			return &UnsupportedSchemaError{Side: s.side, Got: s.got, Want: supportedReportSchema}
+		}
+	}
+	return nil
+}
+
+// loaderMode derives which loader contract produced a report. A baseline taken
+// with the generic validator and a candidate driven by the project's own loader
+// are not the same obligation, so the comparison says so rather than pretending.
+func loaderMode(r schema.ReportV01) string {
+	if r.Command != nil {
+		return "command"
+	}
+	return "artifact"
+}
+
+func refOf(r schema.ReportV01, path string) ReportRef {
+	ref := ReportRef{
+		Path:           path,
+		RunID:          r.Run.ID,
+		SchemaVersion:  r.SchemaVersion,
+		Verdict:        r.Summary.Verdict,
+		Complete:       r.Summary.Complete,
+		ArtifactSHA256: r.Artifact.SHA256,
+		ArtifactSource: r.Artifact.Source,
+		ArtifactDigest: r.Artifact.SourceDigest,
+		LoaderMode:     loaderMode(r),
+	}
+	switch {
+	case r.Command != nil && r.Command.Binary != nil:
+		ref.LoaderSHA256 = r.Command.Binary.SHA256
+	case r.Validator != nil:
+		ref.LoaderSHA256 = r.Validator.SHA256
+	}
+	return ref
+}
+
+func sideOf(t *schema.Target) CellSide {
+	s := CellSide{
+		Present:                true,
+		Verdict:                t.Verdict,
+		Status:                 t.Status,
+		Required:               t.Required,
+		ClassificationCode:     t.ClassificationCode,
+		EnvironmentEstablished: schema.EstablishedRequestedEnvironment(t),
+	}
+	if t.Environment != nil {
+		s.RequestedKernelFamily = t.Environment.RequestedKernelFamily
+		s.ObservedKernel = t.Environment.ObservedKernel
+		s.KernelFamilyMatch = t.Environment.KernelFamilyMatch
+	}
+	return s
+}
+
+// conclusive reports whether a side actually settled the obligation. Only
+// COMPATIBLE and INCOMPATIBLE are answers about the software, and only when the
+// environment that ran was the one the obligation names.
+func conclusive(s CellSide) bool {
+	if !s.Present || !s.EnvironmentEstablished {
+		return false
+	}
+	return s.Verdict == schema.VerdictCompatible || s.Verdict == schema.VerdictIncompatible
+}
+
+// Build compares two reports. It performs no I/O and needs no network.
+func Build(baseline, candidate schema.ReportV01, baselinePath, candidatePath, generatedAt string) Diff {
+	d := Diff{
+		SchemaVersion: SchemaVersion,
+		GeneratedAt:   generatedAt,
+		Baseline:      refOf(baseline, baselinePath),
+		Candidate:     refOf(candidate, candidatePath),
+	}
+
+	// A change of loader contract makes every cell incomparable rather than
+	// wrong: the question "did the candidate regress" has no meaning when the
+	// thing doing the loading also changed.
+	loaderChanged := d.Baseline.LoaderMode != d.Candidate.LoaderMode
+	if loaderChanged {
+		d.Notes = append(d.Notes, fmt.Sprintf(
+			"loader contract changed between reports (baseline=%s candidate=%s); every cell is inconclusive because the comparison would not be like-for-like",
+			d.Baseline.LoaderMode, d.Candidate.LoaderMode))
+	}
+
+	baseByID := indexTargets(baseline.Targets)
+	candByID := indexTargets(candidate.Targets)
+
+	ids := make([]string, 0, len(baseByID)+len(candByID))
+	seen := map[string]bool{}
+	for id := range baseByID {
+		if !seen[id] {
+			ids = append(ids, id)
+			seen[id] = true
+		}
+	}
+	for id := range candByID {
+		if !seen[id] {
+			ids = append(ids, id)
+			seen[id] = true
+		}
+	}
+	// Sorted so the diff is byte-identical regardless of the order targets
+	// appear in either report.
+	sort.Strings(ids)
+
+	for _, id := range ids {
+		bt, hasBase := baseByID[id]
+		ct, hasCand := candByID[id]
+		d.Cells = append(d.Cells, classify(id, bt, hasBase, ct, hasCand, loaderChanged))
+	}
+
+	d.Summary = summarize(d.Cells)
+	d.Summary.BaselineComplete = baseline.Summary.Complete
+	d.Summary.CandidateComplete = candidate.Summary.Complete
+	d.Summary.Result = overallResult(d.Summary)
+	return d
+}
+
+func indexTargets(targets []schema.Target) map[string]*schema.Target {
+	out := make(map[string]*schema.Target, len(targets))
+	for i := range targets {
+		t := &targets[i]
+		id := strings.TrimSpace(t.ProfileID)
+		if id == "" {
+			continue
+		}
+		// A duplicate profile_id in one report makes that obligation ambiguous.
+		// Keep the first and let the cell fall to inconclusive rather than
+		// silently picking a winner.
+		if _, exists := out[id]; exists {
+			continue
+		}
+		out[id] = t
+	}
+	return out
+}
+
+func classify(id string, bt *schema.Target, hasBase bool, ct *schema.Target, hasCand, loaderChanged bool) Cell {
+	cell := Cell{Key: id, ProfileID: id}
+	if hasBase {
+		cell.Baseline = sideOf(bt)
+	}
+	if hasCand {
+		cell.Candidate = sideOf(ct)
+	}
+
+	// Which side decides gating: the candidate defines the release's current
+	// support claims, except when the candidate dropped the obligation
+	// entirely, where the baseline's promise is what was lost.
+	switch {
+	case hasCand:
+		cell.Required = ct.Required
+	case hasBase:
+		cell.Required = bt.Required
+	}
+	if hasBase && hasCand && bt.Required != ct.Required {
+		cell.RequiredChanged = true
+	}
+
+	switch {
+	case !hasBase && !hasCand:
+		cell.Classification = Inconclusive
+		cell.Reason = "obligation present in neither report"
+		return cell
+	case !hasBase:
+		cell.Classification = CoverageAdded
+		cell.Reason = "candidate tests an environment the baseline did not; new evidence, not a regression"
+		return cell
+	case !hasCand:
+		cell.Classification = CoverageRemoved
+		cell.Reason = "baseline tested this environment and the candidate does not; continued support cannot be established"
+		return cell
+	}
+
+	if loaderChanged {
+		cell.Classification = Inconclusive
+		cell.Reason = "loader contract differs between the two reports"
+		return cell
+	}
+
+	// The obligation itself must be the same one. A profile that changed which
+	// kernel series it claims is a different promise wearing the same name.
+	bFam := strings.TrimSpace(cell.Baseline.RequestedKernelFamily)
+	cFam := strings.TrimSpace(cell.Candidate.RequestedKernelFamily)
+	if bFam != "" && cFam != "" && bFam != cFam {
+		cell.Classification = Inconclusive
+		cell.Reason = fmt.Sprintf("the obligation changed: baseline requests kernel family %s, candidate requests %s", bFam, cFam)
+		return cell
+	}
+
+	// Either side failing to settle the question ends the comparison here.
+	// This is the rule that stops an incomplete baseline from manufacturing a
+	// regression out of a candidate failure.
+	if !conclusive(cell.Baseline) || !conclusive(cell.Candidate) {
+		cell.Classification = Inconclusive
+		cell.Reason = inconclusiveReason(cell)
+		return cell
+	}
+
+	switch {
+	case cell.Baseline.Verdict == schema.VerdictCompatible && cell.Candidate.Verdict == schema.VerdictCompatible:
+		cell.Classification = UnchangedCompatible
+		cell.Reason = "supported at baseline and still supported"
+	case cell.Baseline.Verdict == schema.VerdictCompatible && cell.Candidate.Verdict == schema.VerdictIncompatible:
+		cell.Classification = NewRegression
+		cell.Reason = "the baseline proved this environment worked and the candidate proves it no longer does"
+	case cell.Baseline.Verdict == schema.VerdictIncompatible && cell.Candidate.Verdict == schema.VerdictIncompatible:
+		cell.Classification = ExistingIncompatibility
+		cell.Reason = "incompatible at baseline and still incompatible; a known limitation, not a new regression"
+	default:
+		cell.Classification = Fixed
+		cell.Reason = "incompatible at baseline and compatible in the candidate"
+	}
+	return cell
+}
+
+func inconclusiveReason(cell Cell) string {
+	describe := func(side string, s CellSide) string {
+		switch {
+		case !s.Present:
+			return side + " has no evidence for this environment"
+		case !s.EnvironmentEstablished:
+			return fmt.Sprintf("%s requested kernel family %s but ran %s, so it never tested the environment this obligation names",
+				side, s.RequestedKernelFamily, s.ObservedKernel)
+		case s.Verdict == schema.VerdictInfraError:
+			return side + " could not establish compatibility (infrastructure failure)"
+		case s.Verdict == schema.VerdictUnsupported:
+			return side + " could not execute this environment"
+		case s.Verdict == "":
+			return side + " records no verdict"
+		default:
+			return fmt.Sprintf("%s verdict %q is not a compatibility answer", side, s.Verdict)
+		}
+	}
+	var parts []string
+	if !conclusive(cell.Baseline) {
+		parts = append(parts, describe("baseline", cell.Baseline))
+	}
+	if !conclusive(cell.Candidate) {
+		parts = append(parts, describe("candidate", cell.Candidate))
+	}
+	return strings.Join(parts, "; ")
+}
+
+func summarize(cells []Cell) Summary {
+	s := Summary{TotalCells: len(cells)}
+	for i := range cells {
+		c := &cells[i]
+		switch c.Classification {
+		case UnchangedCompatible:
+			s.UnchangedCompatible++
+		case NewRegression:
+			if c.Required {
+				s.NewRequiredRegressions++
+			} else {
+				s.NewOptionalRegressions++
+			}
+		case ExistingIncompatibility:
+			s.ExistingIncompatibility++
+		case Fixed:
+			s.Fixed++
+		case Inconclusive:
+			if c.Required {
+				s.InconclusiveRequired++
+			} else {
+				s.InconclusiveOptional++
+			}
+		case CoverageAdded:
+			s.CoverageAddedCount++
+		case CoverageRemoved:
+			if c.Required {
+				s.CoverageRemovedRequired++
+			} else {
+				s.CoverageRemovedOptional++
+			}
+		}
+	}
+	return s
+}
+
+// overallResult mirrors Gate 1's precedence: a proven regression is a
+// definitive fact about the candidate and outranks an inability to compare
+// somewhere else, so unrelated infrastructure noise cannot bury it.
+func overallResult(s Summary) string {
+	switch {
+	case s.NewRequiredRegressions > 0:
+		return ResultRegressed
+	case s.InconclusiveRequired > 0 || s.CoverageRemovedRequired > 0:
+		return ResultInconclusive
+	default:
+		return ResultNoRegressions
+	}
+}

--- a/internal/regressiondiff/diff.go
+++ b/internal/regressiondiff/diff.go
@@ -559,14 +559,22 @@ func Build(baselineEv, candidateEv Evidence, generatedAt string) (Diff, error) {
 	// A change of loader contract makes every cell incomparable rather than
 	// wrong: the question "did the candidate regress" has no meaning when the
 	// thing doing the loading also changed.
-	loaderChanged := d.Baseline.LoaderMode != d.Candidate.LoaderMode
-	if loaderChanged {
+	// incomparable is non-empty when something about the two runs makes every
+	// cell inconclusive. It carries the reason rather than a flag so that a
+	// cell says what actually changed instead of naming the first cause the
+	// code happened to check.
+	incomparable := ""
+	if d.Baseline.LoaderMode != d.Candidate.LoaderMode {
+		incomparable = fmt.Sprintf("the loader contract differs between the two reports (baseline=%s, candidate=%s)",
+			d.Baseline.LoaderMode, d.Candidate.LoaderMode)
 		d.Notes = append(d.Notes, fmt.Sprintf(
 			"loader contract changed between reports (baseline=%s candidate=%s); every cell is inconclusive because the comparison would not be like-for-like",
 			d.Baseline.LoaderMode, d.Candidate.LoaderMode))
 	}
 	if note, changed := commandContractChanged(baseline, candidate); changed {
-		loaderChanged = true
+		if incomparable == "" {
+			incomparable = note
+		}
 		d.Notes = append(d.Notes, note)
 	}
 	if note, changed := validatorIdentityChanged(d.Baseline, d.Candidate); changed {
@@ -597,7 +605,7 @@ func Build(baselineEv, candidateEv Evidence, generatedAt string) (Diff, error) {
 	for _, id := range ids {
 		bt, hasBase := baseByID[id]
 		ct, hasCand := candByID[id]
-		d.Cells = append(d.Cells, classify(id, bt, hasBase, ct, hasCand, loaderChanged))
+		d.Cells = append(d.Cells, classify(id, bt, hasBase, ct, hasCand, incomparable))
 	}
 
 	d.Summary = summarize(d.Cells)
@@ -619,7 +627,7 @@ func indexTargets(targets []schema.Target) map[string]*schema.Target {
 	return out
 }
 
-func classify(id string, bt *schema.Target, hasBase bool, ct *schema.Target, hasCand, loaderChanged bool) Cell {
+func classify(id string, bt *schema.Target, hasBase bool, ct *schema.Target, hasCand bool, incomparable string) Cell {
 	cell := Cell{Key: id, ProfileID: id}
 	if hasBase {
 		cell.Baseline = sideOf(bt)
@@ -672,9 +680,9 @@ func classify(id string, bt *schema.Target, hasBase bool, ct *schema.Target, has
 		return cell
 	}
 
-	if loaderChanged {
+	if incomparable != "" {
 		cell.Classification = Inconclusive
-		cell.Reason = "loader contract differs between the two reports"
+		cell.Reason = incomparable
 		return cell
 	}
 

--- a/internal/regressiondiff/diff.go
+++ b/internal/regressiondiff/diff.go
@@ -98,9 +98,23 @@ type CellSide struct {
 	RequestedKernelFamily string `json:"requested_kernel_family,omitempty"`
 	ObservedKernel        string `json:"observed_kernel,omitempty"`
 	KernelFamilyMatch     *bool  `json:"kernel_family_match,omitempty"`
-	// EnvironmentEstablished is false when this side ran, but not on the
-	// environment the obligation names.
+	// EnvironmentEstablished is false unless this side positively recorded that
+	// it ran on the environment the obligation names.
 	EnvironmentEstablished bool `json:"environment_established"`
+	// EnvironmentEvidence separates the two ways that can fail: "unknown" (the
+	// report never said what booted) and "mismatch" (it said, and it was the
+	// wrong kernel series). They are not the same finding and must not read as
+	// though they were.
+	EnvironmentEvidence string `json:"environment_evidence,omitempty"`
+	// The requested obligation identity, recorded so a comparison that refused
+	// to treat two sides as the same promise can show why.
+	ProfileArch         string `json:"profile_arch,omitempty"`
+	ProfileDistro       string `json:"profile_distro,omitempty"`
+	ProfileVersion      string `json:"profile_version,omitempty"`
+	ProfileKernelFamily string `json:"profile_kernel_family,omitempty"`
+	// AttachMode is how much of the contract was exercised: load-only evidence
+	// does not support a claim that attaching still works.
+	AttachMode string `json:"attach_mode,omitempty"`
 }
 
 type Cell struct {
@@ -168,7 +182,8 @@ func Validate(r schema.ReportV01, side string) error {
 	}
 	seen := make(map[string]int, len(r.Targets))
 	for i := range r.Targets {
-		id := strings.TrimSpace(r.Targets[i].ProfileID)
+		t := &r.Targets[i]
+		id := strings.TrimSpace(t.ProfileID)
 		if id == "" {
 			return &InvalidEvidenceError{Side: side, Reason: fmt.Sprintf(
 				"target %d has an empty profile_id, so the obligation it represents is unidentifiable", i)}
@@ -178,6 +193,81 @@ func Validate(r schema.ReportV01, side string) error {
 				"profile_id %q appears at targets %d and %d; which result represents that obligation is ambiguous", id, first, i)}
 		}
 		seen[id] = i
+		if err := validateTarget(t, i, id, side); err != nil {
+			return err
+		}
+	}
+	return validateSummary(r, side)
+}
+
+// validateTarget rejects a target that contradicts itself.
+//
+// A report does not become conclusive because one of its fields contains the
+// word COMPATIBLE. `status` and `verdict` are two recordings of one execution:
+// the runner derives the second from the first with schema.VerdictForStatus, so
+// for genuine evidence they agree by construction. When they disagree, the file
+// was edited or written by a producer whose semantics we do not know, and the
+// honest answer is that we cannot compare it -- not that we should pick the
+// field we like. Refusing is also strictly better than resolving the conflict
+// as INCOMPATIBLE, which would blame a candidate for a broken input file.
+func validateTarget(t *schema.Target, i int, id, side string) error {
+	status := strings.TrimSpace(t.Status)
+	verdict := strings.TrimSpace(t.Verdict)
+	// Absence is not contradiction. A pre-Gate-1 report records status and no
+	// verdict; it is unusable as a compatibility claim (conclusive() refuses
+	// it) but it is not self-contradictory, and rejecting the whole file would
+	// confuse "old" with "tampered with".
+	if status != "" && verdict != "" && schema.VerdictForStatus(status) != verdict {
+		return &InvalidEvidenceError{Side: side, Reason: fmt.Sprintf(
+			"target %d (%s) records status %q and verdict %q, which contradict each other (status %q means %q); this report does not agree with itself",
+			i, id, status, verdict, status, schema.VerdictForStatus(status))}
+	}
+	// kernel_family_match is a claim derived from two other fields: the runner
+	// sets it only after parsing a kernel series out of both the requested
+	// family and the observed kernel. A `true` standing alone, with nothing it
+	// could have been derived from, is an assertion rather than evidence.
+	if env := t.Environment; env != nil && env.KernelFamilyMatch != nil {
+		if strings.TrimSpace(env.RequestedKernelFamily) == "" || strings.TrimSpace(env.ObservedKernel) == "" {
+			return &InvalidEvidenceError{Side: side, Reason: fmt.Sprintf(
+				"target %d (%s) states kernel_family_match without recording both the requested kernel family and the observed kernel, so the claim rests on nothing",
+				i, id)}
+		}
+	}
+	return nil
+}
+
+// validateSummary rejects a report whose run-level summary contradicts its own
+// targets.
+//
+// The targets are the single source of semantic truth: they are what the
+// comparison reads, and the summary is derived from them. Rather than choosing
+// which to believe -- or carrying a contradiction forward as if it were
+// trustworthy -- a report that disagrees with itself is refused.
+//
+// These checks deliberately use the lenient package-level helpers, because they
+// reproduce the producer's own computation. Gate 2's stricter reading of
+// missing environment evidence (see establishedEnvironment) applies to what the
+// comparison may conclude, never to whether the producer's arithmetic was
+// self-consistent; using the strict rule here would flag correct reports as
+// forged.
+func validateSummary(r schema.ReportV01, side string) error {
+	status := strings.TrimSpace(r.Summary.Status)
+	verdict := strings.TrimSpace(r.Summary.Verdict)
+	if status != "" && verdict != "" && schema.VerdictForStatus(status) != verdict {
+		return &InvalidEvidenceError{Side: side, Reason: fmt.Sprintf(
+			"summary.status is %q and summary.verdict is %q, which contradict each other; this report does not agree with itself", status, verdict)}
+	}
+	if got := strings.TrimSpace(r.Summary.Verdict); got != "" {
+		if want := schema.RunVerdict(r.Targets); got != want {
+			return &InvalidEvidenceError{Side: side, Reason: fmt.Sprintf(
+				"summary.verdict is %q but its own required targets add up to %q; this report does not agree with itself", got, want)}
+		}
+	}
+	if r.Summary.Complete != nil {
+		if want := schema.RunComplete(r.Targets); *r.Summary.Complete != want {
+			return &InvalidEvidenceError{Side: side, Reason: fmt.Sprintf(
+				"summary.complete is %t but its own targets add up to %t; this report does not agree with itself", *r.Summary.Complete, want)}
+		}
 	}
 	return nil
 }
@@ -216,6 +306,128 @@ func loaderMode(r schema.ReportV01) string {
 	return "artifact"
 }
 
+// checkDistinctRuns refuses a report compared against itself.
+//
+// Run IDs are a UTC timestamp plus a random suffix, so two sides carrying the
+// same non-empty ID are one run read twice -- the usual cause being CI wiring
+// that downloads the same artifact into both paths. Such a comparison is
+// trivially, permanently green: it proves a run equals itself and nothing about
+// a candidate release. A gate that can be satisfied by a wiring mistake is not
+// protecting anything, so this is refused with the reason rather than answered
+// with exit 0. It is an inability to compare, never a claim about the
+// candidate.
+func checkDistinctRuns(baseline, candidate Evidence) error {
+	if id := strings.TrimSpace(baseline.Report.Run.ID); id != "" && id == strings.TrimSpace(candidate.Report.Run.ID) {
+		return &InvalidEvidenceError{Side: "candidate", Reason: fmt.Sprintf(
+			"it is the same run as the baseline (run id %q); comparing a run with itself cannot establish anything about a candidate release", id)}
+	}
+	if baseline.Path != "" && baseline.Path == candidate.Path {
+		return &InvalidEvidenceError{Side: "candidate", Reason: fmt.Sprintf(
+			"it is the same file as the baseline (%s); a release diff needs the evidence of two runs", baseline.Path)}
+	}
+	return nil
+}
+
+// commandContractChanged reports whether two command-mode runs tested the same
+// thing.
+//
+// The loader binary's SHA-256 deliberately does not appear here. In command
+// mode the loader is the project's own program -- it is the thing being
+// released, and requiring it to be identical between release N and N+1 would
+// make every real comparison incomparable. What must hold still is the *test*:
+// the command that was run (recorded as invocation_sha256, the text itself
+// never being published) and the exit code that counts as success. Change
+// either and a later COMPATIBLE is an answer to a different question.
+func commandContractChanged(baseline, candidate schema.ReportV01) (string, bool) {
+	b, c := baseline.Command, candidate.Command
+	if b == nil || c == nil {
+		return "", false
+	}
+	if strings.TrimSpace(b.InvocationSHA256) != "" && strings.TrimSpace(c.InvocationSHA256) != "" &&
+		strings.TrimSpace(b.InvocationSHA256) != strings.TrimSpace(c.InvocationSHA256) {
+		return "the command under test changed between reports (different invocation_sha256); every cell is inconclusive because the two runs answer different questions", true
+	}
+	if b.ExpectedExitCode != c.ExpectedExitCode {
+		return fmt.Sprintf(
+			"the command success contract changed between reports (expected exit code %d at baseline, %d in the candidate); every cell is inconclusive",
+			b.ExpectedExitCode, c.ExpectedExitCode), true
+	}
+	return "", false
+}
+
+// validatorIdentityChanged notes -- and deliberately does not gate on -- a
+// change of the generic validator's build.
+//
+// In artifact mode the validator is bpfcompat's own measuring instrument, and
+// upgrading bpfcompat between a baseline and a candidate is ordinary. Its
+// load/attach contract is stable across its versions by design; that is the
+// premise the whole product rests on. Gating on SHA equality would make every
+// bpfcompat upgrade report every environment as incomparable, which trains
+// users to ignore the gate. What the mismatch is worth is traceability: if a
+// surprising NEW_REGRESSION appears, the first question is whether the
+// instrument changed, and this note puts that in the evidence rather than
+// leaving it to be reconstructed.
+func validatorIdentityChanged(baseline, candidate ReportRef) (string, bool) {
+	if baseline.LoaderMode != "artifact" || candidate.LoaderMode != "artifact" {
+		return "", false
+	}
+	if baseline.LoaderSHA256 == "" || candidate.LoaderSHA256 == "" || baseline.LoaderSHA256 == candidate.LoaderSHA256 {
+		return "", false
+	}
+	return fmt.Sprintf(
+		"the bpfcompat validator build differs between reports (%s -> %s); this is expected across bpfcompat upgrades and does not by itself make the comparison invalid, but it is the first thing to check if a result is surprising",
+		shortSHA(baseline.LoaderSHA256), shortSHA(candidate.LoaderSHA256)), true
+}
+
+// obligationChanged reports whether the two sides of a cell describe the same
+// promise. profile_id is the comparison key, but a key is only as good as the
+// thing it names: the same id can be pointed at a different architecture,
+// distro, release or kernel series by editing a profile, and then a candidate's
+// result is an answer about an environment the baseline never tested. Every
+// field here comes from the profile the matrix *requested*, never from what
+// happened to boot.
+//
+// The artifact SHA-256 and OCI digest are excluded on purpose: release N and
+// N+1 are supposed to differ there, and that is the point of the comparison.
+func obligationChanged(b, c CellSide) (string, bool) {
+	for _, f := range []struct {
+		name, base, cand string
+	}{
+		{"architecture", b.ProfileArch, c.ProfileArch},
+		{"distro", b.ProfileDistro, c.ProfileDistro},
+		{"distro version", b.ProfileVersion, c.ProfileVersion},
+		{"kernel family", b.ProfileKernelFamily, c.ProfileKernelFamily},
+	} {
+		base, cand := strings.TrimSpace(f.base), strings.TrimSpace(f.cand)
+		// Both sides must say, or there is nothing to compare -- an absent
+		// field is unknown, and unknown is handled by the environment rules
+		// rather than being read as a change.
+		if base == "" || cand == "" || base == cand {
+			continue
+		}
+		return fmt.Sprintf(
+			"the obligation changed: this profile names %s %s at baseline and %s in the candidate, so the two results are about different environments",
+			f.name, base, cand), true
+	}
+	return "", false
+}
+
+// validationDepthChanged reports a cell whose two sides exercised different
+// amounts of the contract. A baseline that attached its programs and a
+// candidate that only loaded them are not comparable evidence: the candidate's
+// COMPATIBLE says nothing about attaching, which is exactly what the baseline
+// proved. This fails closed in the direction that matters -- the shallower
+// candidate cannot inherit the deeper baseline's green.
+func validationDepthChanged(b, c CellSide) (string, bool) {
+	base, cand := strings.TrimSpace(b.AttachMode), strings.TrimSpace(c.AttachMode)
+	if base == "" || cand == "" || base == cand {
+		return "", false
+	}
+	return fmt.Sprintf(
+		"the validation contract changed: attach mode %q at baseline and %q in the candidate, so the two runs exercised different amounts of the contract",
+		base, cand), true
+}
+
 func refOf(r schema.ReportV01, path string) ReportRef {
 	ref := ReportRef{
 		Path:           path,
@@ -237,26 +449,71 @@ func refOf(r schema.ReportV01, path string) ReportRef {
 	return ref
 }
 
+// Environment evidence states, recorded per side so the JSON says which of the
+// two very different reasons a cell was not established.
+const (
+	EnvironmentEstablishedEvidence = "established"
+	EnvironmentUnknownEvidence     = "unknown"
+	EnvironmentMismatchEvidence    = "mismatch"
+)
+
+// establishedEnvironment is Gate 2's reading of whether a target actually
+// exercised the environment its obligation names.
+//
+// It is deliberately stricter than schema.EstablishedRequestedEnvironment,
+// which answers true when the evidence is absent. That leniency is right for
+// the Gate 1 helper: a report reader must not invent a failure out of a field
+// an older bpfcompat never wrote, and RunVerdict uses it to avoid blaming a
+// user's software for our missing metadata. It is not right here. A release
+// gate is asked "do we positively know this candidate still supports the
+// environment we promise?", and "the file does not say" is not a yes. Changing
+// the shared helper would silently restate every existing consumer's contract,
+// so the strictness lives here, where the stricter question is asked.
+//
+// Unknown is kept distinct from mismatch. A file that never recorded a kernel
+// is not evidence that the wrong kernel booted, and the reason text must not
+// claim it is.
+func establishedEnvironment(t *schema.Target) string {
+	if t.Environment == nil || t.Environment.KernelFamilyMatch == nil {
+		return EnvironmentUnknownEvidence
+	}
+	if !*t.Environment.KernelFamilyMatch {
+		return EnvironmentMismatchEvidence
+	}
+	return EnvironmentEstablishedEvidence
+}
+
 func sideOf(t *schema.Target) CellSide {
+	evidence := establishedEnvironment(t)
 	s := CellSide{
 		Present:                true,
 		Verdict:                t.Verdict,
 		Status:                 t.Status,
 		Required:               t.Required,
 		ClassificationCode:     t.ClassificationCode,
-		EnvironmentEstablished: schema.EstablishedRequestedEnvironment(t),
+		EnvironmentEvidence:    evidence,
+		EnvironmentEstablished: evidence == EnvironmentEstablishedEvidence,
 	}
 	if t.Environment != nil {
 		s.RequestedKernelFamily = t.Environment.RequestedKernelFamily
 		s.ObservedKernel = t.Environment.ObservedKernel
 		s.KernelFamilyMatch = t.Environment.KernelFamilyMatch
 	}
+	if t.Profile != nil {
+		s.ProfileArch = t.Profile.Arch
+		s.ProfileDistro = t.Profile.Distro
+		s.ProfileVersion = t.Profile.Version
+		s.ProfileKernelFamily = t.Profile.KernelFamily
+	}
+	if t.Validation != nil {
+		s.AttachMode = t.Validation.AttachMode
+	}
 	return s
 }
 
 // conclusive reports whether a side actually settled the obligation. Only
 // COMPATIBLE and INCOMPATIBLE are answers about the software, and only when the
-// environment that ran was the one the obligation names.
+// environment that ran is positively known to be the one the obligation names.
 func conclusive(s CellSide) bool {
 	if !s.Present || !s.EnvironmentEstablished {
 		return false
@@ -269,18 +526,34 @@ func conclusive(s CellSide) bool {
 // It returns an error rather than a Diff whenever the inputs cannot supply
 // trustworthy comparison keys, so there is no path that produces a diff from
 // evidence the differ had to guess about.
-func Build(baseline, candidate schema.ReportV01, baselinePath, candidatePath, generatedAt string) (Diff, error) {
+func Build(baselineEv, candidateEv Evidence, generatedAt string) (Diff, error) {
+	baseline, candidate := baselineEv.Report, candidateEv.Report
+	// Re-checked here, not only on the load path, so that no caller can reach a
+	// diff without them: these are the conditions under which the comparison
+	// has meaning at all.
+	if err := CheckSchemas(baseline, candidate); err != nil {
+		return Diff{}, err
+	}
 	if err := Validate(baseline, "baseline"); err != nil {
 		return Diff{}, err
 	}
 	if err := Validate(candidate, "candidate"); err != nil {
 		return Diff{}, err
 	}
+	if err := baselineEv.validatePresence(); err != nil {
+		return Diff{}, err
+	}
+	if err := candidateEv.validatePresence(); err != nil {
+		return Diff{}, err
+	}
+	if err := checkDistinctRuns(baselineEv, candidateEv); err != nil {
+		return Diff{}, err
+	}
 	d := Diff{
 		SchemaVersion: SchemaVersion,
 		GeneratedAt:   generatedAt,
-		Baseline:      refOf(baseline, baselinePath),
-		Candidate:     refOf(candidate, candidatePath),
+		Baseline:      refOf(baseline, baselineEv.Path),
+		Candidate:     refOf(candidate, candidateEv.Path),
 	}
 
 	// A change of loader contract makes every cell incomparable rather than
@@ -291,6 +564,13 @@ func Build(baseline, candidate schema.ReportV01, baselinePath, candidatePath, ge
 		d.Notes = append(d.Notes, fmt.Sprintf(
 			"loader contract changed between reports (baseline=%s candidate=%s); every cell is inconclusive because the comparison would not be like-for-like",
 			d.Baseline.LoaderMode, d.Candidate.LoaderMode))
+	}
+	if note, changed := commandContractChanged(baseline, candidate); changed {
+		loaderChanged = true
+		d.Notes = append(d.Notes, note)
+	}
+	if note, changed := validatorIdentityChanged(d.Baseline, d.Candidate); changed {
+		d.Notes = append(d.Notes, note)
 	}
 
 	baseByID := indexTargets(baseline.Targets)
@@ -370,6 +650,19 @@ func classify(id string, bt *schema.Target, hasBase bool, ct *schema.Target, has
 		cell.Reason = "obligation present in neither report"
 		return cell
 	case !hasBase:
+		// Coverage was only added if the candidate actually established
+		// something. A new obligation whose run hit an infrastructure failure,
+		// or never recorded which kernel it ran, has added a row and no
+		// evidence -- and calling that COVERAGE_ADDED would let a required
+		// obligation nothing settled pass through a green gate. It also closes
+		// the reverse edit: deleting a target from the *baseline* would
+		// otherwise turn an inconclusive required cell into a non-gating one.
+		if !conclusive(cell.Candidate) {
+			cell.Classification = Inconclusive
+			cell.Reason = "candidate adds an obligation the baseline did not test, but did not establish it: " +
+				describeSide("candidate", cell.Candidate)
+			return cell
+		}
 		cell.Classification = CoverageAdded
 		cell.Reason = "candidate tests an environment the baseline did not; new evidence, not a regression"
 		return cell
@@ -408,6 +701,16 @@ func classify(id string, bt *schema.Target, hasBase bool, ct *schema.Target, has
 		cell.Reason = fmt.Sprintf("the obligation changed: baseline requests kernel family %s, candidate requests %s", bFam, cFam)
 		return cell
 	}
+	if reason, changed := obligationChanged(cell.Baseline, cell.Candidate); changed {
+		cell.Classification = Inconclusive
+		cell.Reason = reason
+		return cell
+	}
+	if reason, changed := validationDepthChanged(cell.Baseline, cell.Candidate); changed {
+		cell.Classification = Inconclusive
+		cell.Reason = reason
+		return cell
+	}
 
 	// Either side failing to settle the question ends the comparison here.
 	// This is the rule that stops an incomplete baseline from manufacturing a
@@ -435,30 +738,37 @@ func classify(id string, bt *schema.Target, hasBase bool, ct *schema.Target, has
 	return cell
 }
 
-func inconclusiveReason(cell Cell) string {
-	describe := func(side string, s CellSide) string {
-		switch {
-		case !s.Present:
-			return side + " has no evidence for this environment"
-		case !s.EnvironmentEstablished:
-			return fmt.Sprintf("%s requested kernel family %s but ran %s, so it never tested the environment this obligation names",
-				side, s.RequestedKernelFamily, s.ObservedKernel)
-		case s.Verdict == schema.VerdictInfraError:
-			return side + " could not establish compatibility (infrastructure failure)"
-		case s.Verdict == schema.VerdictUnsupported:
-			return side + " could not execute this environment"
-		case s.Verdict == "":
-			return side + " records no verdict"
-		default:
-			return fmt.Sprintf("%s verdict %q is not a compatibility answer", side, s.Verdict)
-		}
+// describeSide says, in one clause, why one side did not settle its obligation.
+func describeSide(side string, s CellSide) string {
+	switch {
+	case !s.Present:
+		return side + " has no evidence for this environment"
+	case s.EnvironmentEvidence == EnvironmentMismatchEvidence:
+		return fmt.Sprintf("%s requested kernel family %s but ran %s, so it never tested the environment this obligation names",
+			side, s.RequestedKernelFamily, s.ObservedKernel)
+	case s.EnvironmentEvidence == EnvironmentUnknownEvidence:
+		// Deliberately not phrased as a mismatch: the report does not say
+		// what booted, which is a different fact from booting the wrong
+		// thing, and only one of them is a finding about the environment.
+		return side + " does not record which kernel it ran (no environment.kernel_family_match), so it cannot support a claim about the environment this obligation names"
+	case s.Verdict == schema.VerdictInfraError:
+		return side + " could not establish compatibility (infrastructure failure)"
+	case s.Verdict == schema.VerdictUnsupported:
+		return side + " could not execute this environment"
+	case s.Verdict == "":
+		return side + " records no verdict"
+	default:
+		return fmt.Sprintf("%s verdict %q is not a compatibility answer", side, s.Verdict)
 	}
+}
+
+func inconclusiveReason(cell Cell) string {
 	var parts []string
 	if !conclusive(cell.Baseline) {
-		parts = append(parts, describe("baseline", cell.Baseline))
+		parts = append(parts, describeSide("baseline", cell.Baseline))
 	}
 	if !conclusive(cell.Candidate) {
-		parts = append(parts, describe("candidate", cell.Candidate))
+		parts = append(parts, describeSide("candidate", cell.Candidate))
 	}
 	return strings.Join(parts, "; ")
 }

--- a/internal/regressiondiff/diff.go
+++ b/internal/regressiondiff/diff.go
@@ -143,6 +143,45 @@ type Diff struct {
 	Notes         []string  `json:"notes,omitempty"`
 }
 
+// InvalidEvidenceError is returned when a report cannot supply trustworthy
+// comparison keys. Every case here is an inability to compare, never a verdict
+// on the candidate, so the caller maps it to exit 1.
+type InvalidEvidenceError struct {
+	Side, Reason string
+}
+
+func (e *InvalidEvidenceError) Error() string {
+	return fmt.Sprintf("%s report cannot be compared: %s", e.Side, e.Reason)
+}
+
+// Validate rejects evidence whose comparison keys cannot be trusted.
+//
+// Each of these was previously tolerated, and each let a diff look conclusive
+// when it was not: a report with no targets compared cleanly against anything,
+// a blank profile_id silently vanished from the comparison, and a duplicated
+// profile_id had its first occurrence silently chosen as the winner. Ambiguity
+// about *which* obligation a cell represents is not something a release gate
+// may resolve by guessing.
+func Validate(r schema.ReportV01, side string) error {
+	if len(r.Targets) == 0 {
+		return &InvalidEvidenceError{Side: side, Reason: "it contains no targets, so it establishes nothing to compare"}
+	}
+	seen := make(map[string]int, len(r.Targets))
+	for i := range r.Targets {
+		id := strings.TrimSpace(r.Targets[i].ProfileID)
+		if id == "" {
+			return &InvalidEvidenceError{Side: side, Reason: fmt.Sprintf(
+				"target %d has an empty profile_id, so the obligation it represents is unidentifiable", i)}
+		}
+		if first, dup := seen[id]; dup {
+			return &InvalidEvidenceError{Side: side, Reason: fmt.Sprintf(
+				"profile_id %q appears at targets %d and %d; which result represents that obligation is ambiguous", id, first, i)}
+		}
+		seen[id] = i
+	}
+	return nil
+}
+
 // UnsupportedSchemaError is returned when a report's schema is not one this
 // differ understands. Comparing it anyway would guess at semantics.
 type UnsupportedSchemaError struct {
@@ -226,7 +265,17 @@ func conclusive(s CellSide) bool {
 }
 
 // Build compares two reports. It performs no I/O and needs no network.
-func Build(baseline, candidate schema.ReportV01, baselinePath, candidatePath, generatedAt string) Diff {
+//
+// It returns an error rather than a Diff whenever the inputs cannot supply
+// trustworthy comparison keys, so there is no path that produces a diff from
+// evidence the differ had to guess about.
+func Build(baseline, candidate schema.ReportV01, baselinePath, candidatePath, generatedAt string) (Diff, error) {
+	if err := Validate(baseline, "baseline"); err != nil {
+		return Diff{}, err
+	}
+	if err := Validate(candidate, "candidate"); err != nil {
+		return Diff{}, err
+	}
 	d := Diff{
 		SchemaVersion: SchemaVersion,
 		GeneratedAt:   generatedAt,
@@ -275,24 +324,17 @@ func Build(baseline, candidate schema.ReportV01, baselinePath, candidatePath, ge
 	d.Summary.BaselineComplete = baseline.Summary.Complete
 	d.Summary.CandidateComplete = candidate.Summary.Complete
 	d.Summary.Result = overallResult(d.Summary)
-	return d
+	return d, nil
 }
 
+// indexTargets assumes Validate has already run, so every profile_id is present
+// and unique. It never drops or de-duplicates anything: a comparison key that
+// cannot be trusted is rejected before this point, not quietly resolved here.
 func indexTargets(targets []schema.Target) map[string]*schema.Target {
 	out := make(map[string]*schema.Target, len(targets))
 	for i := range targets {
 		t := &targets[i]
-		id := strings.TrimSpace(t.ProfileID)
-		if id == "" {
-			continue
-		}
-		// A duplicate profile_id in one report makes that obligation ambiguous.
-		// Keep the first and let the cell fall to inconclusive rather than
-		// silently picking a winner.
-		if _, exists := out[id]; exists {
-			continue
-		}
-		out[id] = t
+		out[strings.TrimSpace(t.ProfileID)] = t
 	}
 	return out
 }
@@ -306,17 +348,20 @@ func classify(id string, bt *schema.Target, hasBase bool, ct *schema.Target, has
 		cell.Candidate = sideOf(ct)
 	}
 
-	// Which side decides gating: the candidate defines the release's current
-	// support claims, except when the candidate dropped the obligation
-	// entirely, where the baseline's promise is what was lost.
+	// Gating follows whichever side treated the obligation as required.
+	//
+	// Letting the candidate alone decide was a hole: demoting a profile to
+	// `required: false` in the candidate turned a regression on an environment
+	// the baseline promised into a non-gating optional finding, so a release
+	// could dodge the gate by editing its own matrix.
 	switch {
+	case hasBase && hasCand:
+		cell.Required = bt.Required || ct.Required
+		cell.RequiredChanged = bt.Required != ct.Required
 	case hasCand:
 		cell.Required = ct.Required
 	case hasBase:
 		cell.Required = bt.Required
-	}
-	if hasBase && hasCand && bt.Required != ct.Required {
-		cell.RequiredChanged = true
 	}
 
 	switch {
@@ -337,6 +382,20 @@ func classify(id string, bt *schema.Target, hasBase bool, ct *schema.Target, has
 	if loaderChanged {
 		cell.Classification = Inconclusive
 		cell.Reason = "loader contract differs between the two reports"
+		return cell
+	}
+
+	// A requiredness change is a change to the support contract, not to the
+	// software. Whether a candidate "regressed" against a promise that did not
+	// exist at baseline -- or still honours one it has since dropped -- is not
+	// something this evidence can settle, in either direction. Both sides of the
+	// change are treated as not-like-for-like rather than reasoning
+	// asymmetrically about which direction is safe.
+	if cell.RequiredChanged {
+		cell.Classification = Inconclusive
+		cell.Reason = fmt.Sprintf(
+			"the support contract changed: this environment is required=%t at baseline and required=%t in the candidate, so the two results are not like-for-like",
+			cell.Baseline.Required, cell.Candidate.Required)
 		return cell
 	}
 

--- a/internal/regressiondiff/diff_test.go
+++ b/internal/regressiondiff/diff_test.go
@@ -454,3 +454,53 @@ func TestDiffJSONIsVersionedAndSelfDescribing(t *testing.T) {
 		t.Fatal("candidate incompleteness must be surfaced in the summary")
 	}
 }
+
+// Evidence must be the whole file, not its first JSON value. json.Decoder.Decode
+// stops after one value and leaves the rest unread, so a truncated or
+// concatenated report compared cleanly from its first value alone -- exit 0 over
+// a file nobody can vouch for.
+func TestTrailingDataAfterTheReportIsRefused(t *testing.T) {
+	dir := t.TempDir()
+	valid, err := json.Marshal(report(true, target("k", schema.VerdictCompatible, true)))
+	if err != nil {
+		t.Fatal(err)
+	}
+	good := filepath.Join(dir, "good.json")
+	if err := os.WriteFile(good, valid, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name    string
+		trailer string
+	}{
+		{"second JSON value", "\n{\"schema_version\":\"v0.1\"}\n"},
+		{"stray bytes", "\ngarbage\n"},
+		{"truncated append", "\n{\"targets\":"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			path := filepath.Join(dir, "trailing.json")
+			if err := os.WriteFile(path, append(append([]byte{}, valid...), tc.trailer...), 0o600); err != nil {
+				t.Fatal(err)
+			}
+			if _, err := LoadReport(path); err == nil {
+				t.Fatal("a report with trailing data was accepted, so only its first value would have been compared")
+			}
+			if _, err := Compare(path, good, time.Now()); err == nil {
+				t.Fatal("Compare accepted a baseline with trailing data")
+			}
+			if _, err := Compare(good, path, time.Now()); err == nil {
+				t.Fatal("Compare accepted a candidate with trailing data")
+			}
+		})
+	}
+
+	// Trailing whitespace is not trailing data.
+	padded := filepath.Join(dir, "padded.json")
+	if err := os.WriteFile(padded, append(append([]byte{}, valid...), "\n\n  \n"...), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadReport(padded); err != nil {
+		t.Fatalf("whitespace after the report must be fine: %v", err)
+	}
+}

--- a/internal/regressiondiff/diff_test.go
+++ b/internal/regressiondiff/diff_test.go
@@ -1,0 +1,313 @@
+package regressiondiff
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/kernel-guard/bpfcompat/pkg/schema"
+)
+
+func b(v bool) *bool { return &v }
+
+// target builds one side's evidence for a profile. Verdict is what the run
+// recorded; the differ must never derive it itself.
+func target(id, verdict string, required bool) schema.Target {
+	status := map[string]string{
+		schema.VerdictCompatible:   "pass",
+		schema.VerdictIncompatible: "fail",
+		schema.VerdictInfraError:   "infra_error",
+		schema.VerdictUnsupported:  "unsupported",
+	}[verdict]
+	return schema.Target{
+		ProfileID: id, Required: required, Status: status, Verdict: verdict,
+		Environment: &schema.EnvironmentCheck{
+			RequestedKernelFamily: "5.15",
+			ObservedKernel:        "5.15.0-186-generic",
+			KernelFamilyMatch:     b(true),
+		},
+	}
+}
+
+// mismatched marks a target as having run a kernel other than the one its
+// profile names -- real evidence, but not about the requested obligation.
+func mismatched(t schema.Target) schema.Target {
+	t.Environment = &schema.EnvironmentCheck{
+		RequestedKernelFamily: "5.15",
+		ObservedKernel:        "6.12.0-107.el9uek.x86_64",
+		KernelFamilyMatch:     b(false),
+	}
+	return t
+}
+
+func report(complete bool, targets ...schema.Target) schema.ReportV01 {
+	return schema.ReportV01{
+		SchemaVersion: "v0.1",
+		Run:           schema.RunInfo{ID: "run-x"},
+		Artifact:      schema.Artifact{SHA256: "aaa"},
+		Targets:       targets,
+		Summary:       schema.SummaryInfo{Verdict: schema.VerdictCompatible, Complete: b(complete)},
+	}
+}
+
+func build(t *testing.T, baseline, candidate schema.ReportV01) Diff {
+	t.Helper()
+	return Build(baseline, candidate, "base.json", "cand.json", time.Unix(0, 0).UTC().Format(time.RFC3339))
+}
+
+func onlyCell(t *testing.T, d Diff) Cell {
+	t.Helper()
+	if len(d.Cells) != 1 {
+		t.Fatalf("expected exactly one cell, got %d", len(d.Cells))
+	}
+	return d.Cells[0]
+}
+
+// The comparison table. Each row is a release decision that must differ.
+func TestComparisonTable(t *testing.T) {
+	C, I := schema.VerdictCompatible, schema.VerdictIncompatible
+	E, U := schema.VerdictInfraError, schema.VerdictUnsupported
+
+	tests := []struct {
+		name       string
+		baseline   *schema.Target
+		candidate  *schema.Target
+		want       string
+		wantResult string
+		wantExit   int
+	}{
+		{"compatible to compatible", p(target("k", C, true)), p(target("k", C, true)), UnchangedCompatible, ResultNoRegressions, 0},
+		{"compatible to incompatible is the product signal", p(target("k", C, true)), p(target("k", I, true)), NewRegression, ResultRegressed, 2},
+		{"incompatible to incompatible is a known limitation", p(target("k", I, true)), p(target("k", I, true)), ExistingIncompatibility, ResultNoRegressions, 0},
+		{"incompatible to compatible is a fix", p(target("k", I, true)), p(target("k", C, true)), Fixed, ResultNoRegressions, 0},
+
+		// The rule that stops an unproven baseline from inventing a regression.
+		{"infra baseline then incompatible candidate is NOT a regression", p(target("k", E, true)), p(target("k", I, true)), Inconclusive, ResultInconclusive, 1},
+		{"compatible baseline then infra candidate", p(target("k", C, true)), p(target("k", E, true)), Inconclusive, ResultInconclusive, 1},
+		{"unsupported on either side", p(target("k", U, true)), p(target("k", C, true)), Inconclusive, ResultInconclusive, 1},
+
+		// Environment mislabels are evidence-quality failures, not regressions.
+		{"required baseline ran the wrong kernel", p(mismatched(target("k", C, true))), p(target("k", I, true)), Inconclusive, ResultInconclusive, 1},
+		{"required candidate ran the wrong kernel", p(target("k", C, true)), p(mismatched(target("k", C, true))), Inconclusive, ResultInconclusive, 1},
+
+		// Optional cells report, they do not gate.
+		{"optional regression is visible but non-gating", p(target("k", C, false)), p(target("k", I, false)), NewRegression, ResultNoRegressions, 0},
+		{"optional inconclusive is non-gating", p(target("k", C, false)), p(target("k", E, false)), Inconclusive, ResultNoRegressions, 0},
+
+		// Coverage changes.
+		{"required coverage removed cannot establish continued support", p(target("k", C, true)), nil, CoverageRemoved, ResultInconclusive, 1},
+		{"optional coverage removed is non-gating", p(target("k", C, false)), nil, CoverageRemoved, ResultNoRegressions, 0},
+		{"candidate-only cell is new evidence", nil, p(target("k", C, true)), CoverageAdded, ResultNoRegressions, 0},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			var baseTargets, candTargets []schema.Target
+			if tc.baseline != nil {
+				baseTargets = append(baseTargets, *tc.baseline)
+			}
+			if tc.candidate != nil {
+				candTargets = append(candTargets, *tc.candidate)
+			}
+			d := build(t, report(true, baseTargets...), report(true, candTargets...))
+			cell := onlyCell(t, d)
+			if cell.Classification != tc.want {
+				t.Errorf("classification: want %s, got %s (%s)", tc.want, cell.Classification, cell.Reason)
+			}
+			if d.Summary.Result != tc.wantResult {
+				t.Errorf("result: want %s, got %s", tc.wantResult, d.Summary.Result)
+			}
+			if got := ExitCode(d); got != tc.wantExit {
+				t.Errorf("exit: want %d, got %d", tc.wantExit, got)
+			}
+		})
+	}
+}
+
+func p(t schema.Target) *schema.Target { return &t }
+
+// The single most important property of this whole gate.
+func TestIncompleteBaselineCanNeverManufactureARegression(t *testing.T) {
+	C, I := schema.VerdictCompatible, schema.VerdictIncompatible
+	unproven := []schema.Target{
+		target("k", schema.VerdictInfraError, true),
+		target("k", schema.VerdictUnsupported, true),
+		mismatched(target("k", C, true)),
+		{ProfileID: "k", Required: true, Status: "pass"}, // no verdict recorded at all
+	}
+	for _, base := range unproven {
+		d := build(t, report(false, base), report(true, target("k", I, true)))
+		cell := onlyCell(t, d)
+		if cell.Classification == NewRegression {
+			t.Fatalf("baseline %q/%v produced NEW_REGRESSION from an unproven baseline",
+				base.Verdict, base.Environment)
+		}
+		if cell.Classification != Inconclusive {
+			t.Fatalf("want %s, got %s", Inconclusive, cell.Classification)
+		}
+		// The candidate's incompatibility must still be visible as evidence.
+		if cell.Candidate.Verdict != I {
+			t.Fatalf("candidate evidence was discarded: %+v", cell.Candidate)
+		}
+	}
+}
+
+// The mirror property: a proven required regression must survive noise.
+func TestProvenRequiredRegressionSurvivesUnrelatedNoise(t *testing.T) {
+	C, I := schema.VerdictCompatible, schema.VerdictIncompatible
+	baseline := report(true,
+		target("gating", C, true),
+		target("flaky-optional", C, false),
+		target("also-required", C, true),
+	)
+	candidate := report(false,
+		target("gating", I, true),                                 // the real regression
+		target("flaky-optional", schema.VerdictInfraError, false), // optional noise
+		target("also-required", schema.VerdictInfraError, true),   // required noise
+	)
+	d := build(t, baseline, candidate)
+	if d.Summary.NewRequiredRegressions != 1 {
+		t.Fatalf("want 1 new required regression, got %d", d.Summary.NewRequiredRegressions)
+	}
+	if d.Summary.Result != ResultRegressed {
+		t.Fatalf("a proven required regression must outrank inconclusive noise; got %s", d.Summary.Result)
+	}
+	if ExitCode(d) != ExitRegressed {
+		t.Fatalf("want exit %d, got %d", ExitRegressed, ExitCode(d))
+	}
+	// ...and the noise is still counted, not hidden.
+	if d.Summary.InconclusiveRequired != 1 || d.Summary.InconclusiveOptional != 1 {
+		t.Fatalf("lost coverage must remain visible: %+v", d.Summary)
+	}
+}
+
+func TestOrderIndependence(t *testing.T) {
+	C, I := schema.VerdictCompatible, schema.VerdictIncompatible
+	a := report(true, target("a", C, true), target("b", I, true), target("c", C, false))
+	bRep := report(true, target("c", C, false), target("a", I, true), target("b", I, true))
+	shuffled := report(true, target("b", I, true), target("c", C, false), target("a", C, true))
+	shuffledCand := report(true, target("b", I, true), target("a", I, true), target("c", C, false))
+
+	d1 := build(t, a, bRep)
+	d2 := build(t, shuffled, shuffledCand)
+
+	j1, _ := json.Marshal(d1.Cells)
+	j2, _ := json.Marshal(d2.Cells)
+	if !bytes.Equal(j1, j2) {
+		t.Fatalf("diff depends on target order:\n%s\n%s", j1, j2)
+	}
+	if d1.Summary.Result != d2.Summary.Result {
+		t.Fatalf("result depends on order: %s vs %s", d1.Summary.Result, d2.Summary.Result)
+	}
+}
+
+func TestLoaderContractChangeMakesEveryCellInconclusive(t *testing.T) {
+	C := schema.VerdictCompatible
+	baseline := report(true, target("k", C, true))
+	baseline.Validator = &schema.BinaryIdentity{SHA256: "validator"}
+	candidate := report(true, target("k", C, true))
+	candidate.Command = &schema.CommandInfo{InvocationSHA256: "inv"}
+
+	d := build(t, baseline, candidate)
+	if onlyCell(t, d).Classification != Inconclusive {
+		t.Fatal("a baseline loaded by the generic validator and a candidate driven by its own loader are not the same obligation")
+	}
+	if len(d.Notes) == 0 {
+		t.Fatal("the loader change must be stated, not silently applied")
+	}
+}
+
+func TestChangedObligationIsInconclusive(t *testing.T) {
+	C := schema.VerdictCompatible
+	base := target("k", C, true)
+	cand := target("k", C, true)
+	cand.Environment.RequestedKernelFamily = "6.1" // the profile now promises a different series
+	d := build(t, report(true, base), report(true, cand))
+	cell := onlyCell(t, d)
+	if cell.Classification != Inconclusive {
+		t.Fatalf("a profile that changed which kernel it claims is a different promise; got %s", cell.Classification)
+	}
+}
+
+func TestRequiredFlagFollowsTheCandidateAndRecordsChanges(t *testing.T) {
+	C, I := schema.VerdictCompatible, schema.VerdictIncompatible
+	// Demoting a required profile to optional must be visible.
+	d := build(t, report(true, target("k", C, true)), report(true, target("k", I, false)))
+	cell := onlyCell(t, d)
+	if !cell.RequiredChanged {
+		t.Fatal("a required->optional demotion must be recorded")
+	}
+	if cell.Required {
+		t.Fatal("the candidate defines the current support claim")
+	}
+	if d.Summary.NewOptionalRegressions != 1 {
+		t.Fatalf("expected the regression to be counted as optional: %+v", d.Summary)
+	}
+}
+
+func TestUnsupportedSchemaFailsClosed(t *testing.T) {
+	good := report(true, target("k", schema.VerdictCompatible, true))
+	for _, bad := range []string{"", "v0.2", "v1.0", "nonsense"} {
+		other := good
+		other.SchemaVersion = bad
+		if err := CheckSchemas(other, good); err == nil {
+			t.Errorf("baseline schema %q was accepted", bad)
+		}
+		if err := CheckSchemas(good, other); err == nil {
+			t.Errorf("candidate schema %q was accepted", bad)
+		}
+	}
+	if err := CheckSchemas(good, good); err != nil {
+		t.Fatalf("matching supported schemas must compare: %v", err)
+	}
+}
+
+func TestMalformedAndMissingEvidenceFailClosed(t *testing.T) {
+	dir := t.TempDir()
+	good := filepath.Join(dir, "good.json")
+	blob, _ := json.Marshal(report(true, target("k", schema.VerdictCompatible, true)))
+	if err := os.WriteFile(good, blob, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	bad := filepath.Join(dir, "bad.json")
+	if err := os.WriteFile(bad, []byte("{not json"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct{ name, baseline, candidate string }{
+		{"malformed baseline", bad, good},
+		{"malformed candidate", good, bad},
+		{"missing baseline", filepath.Join(dir, "nope.json"), good},
+		{"missing candidate", good, filepath.Join(dir, "nope.json")},
+	} {
+		if _, err := Compare(tc.baseline, tc.candidate, time.Now()); err == nil {
+			t.Errorf("%s: expected an error rather than an empty comparison", tc.name)
+		}
+	}
+}
+
+func TestDiffJSONIsVersionedAndSelfDescribing(t *testing.T) {
+	d := build(t, report(true, target("k", schema.VerdictCompatible, true)),
+		report(false, target("k", schema.VerdictIncompatible, true)))
+	blob, err := json.Marshal(d)
+	if err != nil {
+		t.Fatal(err)
+	}
+	var generic map[string]any
+	if err := json.Unmarshal(blob, &generic); err != nil {
+		t.Fatal(err)
+	}
+	if generic["schema_version"] != SchemaVersion {
+		t.Fatalf("diff must carry its own schema version, got %v", generic["schema_version"])
+	}
+	// It must not be mistakable for a run report.
+	if generic["schema_version"] == "v0.1" {
+		t.Fatal("the diff schema must be distinct from the run-report schema")
+	}
+	if d.Summary.CandidateComplete == nil || *d.Summary.CandidateComplete {
+		t.Fatal("candidate incompleteness must be surfaced in the summary")
+	}
+}

--- a/internal/regressiondiff/diff_test.go
+++ b/internal/regressiondiff/diff_test.go
@@ -4,9 +4,11 @@ import (
 	"bytes"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -14,6 +16,19 @@ import (
 )
 
 func b(v bool) *bool { return &v }
+
+// runStatus mirrors the runner's run-level status vocabulary (pass/fail/error),
+// which differs from the per-target one.
+func runStatus(verdict string) string {
+	switch verdict {
+	case schema.VerdictIncompatible:
+		return "fail"
+	case schema.VerdictInfraError:
+		return "error"
+	default:
+		return "pass"
+	}
+}
 
 // target builds one side's evidence for a profile. Verdict is what the run
 // recorded; the differ must never derive it itself.
@@ -45,23 +60,46 @@ func mismatched(t schema.Target) schema.Target {
 	return t
 }
 
-func report(complete bool, targets ...schema.Target) schema.ReportV01 {
+// runIDs hands every fixture its own run identity. Real run IDs are a
+// timestamp plus a random suffix, and two reports sharing one are the same run
+// read twice -- which the differ refuses, so fixtures must not accidentally
+// claim it.
+var runIDs atomic.Int64
+
+// report builds a self-consistent report: its run-level summary is computed
+// from its own targets exactly as the runner computes it. Reports whose summary
+// contradicts their targets are refused as evidence, so a fixture that hand-set
+// one would be testing the rejection path rather than whatever it meant to
+// test. The contradictory cases are built explicitly, in the tests that are
+// about them.
+func report(targets ...schema.Target) schema.ReportV01 {
 	return schema.ReportV01{
 		SchemaVersion: "v0.1",
-		Run:           schema.RunInfo{ID: "run-x"},
+		Run:           schema.RunInfo{ID: fmt.Sprintf("run-%d", runIDs.Add(1))},
 		Artifact:      schema.Artifact{SHA256: "aaa"},
 		Targets:       targets,
-		Summary:       schema.SummaryInfo{Verdict: schema.VerdictCompatible, Complete: b(complete)},
+		Summary: schema.SummaryInfo{
+			Status:   runStatus(schema.RunVerdict(targets)),
+			Verdict:  schema.RunVerdict(targets),
+			Complete: b(schema.RunComplete(targets)),
+		},
 	}
 }
 
 func build(t *testing.T, baseline, candidate schema.ReportV01) Diff {
 	t.Helper()
-	d, err := Build(baseline, candidate, "base.json", "cand.json", time.Unix(0, 0).UTC().Format(time.RFC3339))
+	d, err := buildErr(baseline, candidate)
 	if err != nil {
 		t.Fatalf("build: %v", err)
 	}
 	return d
+}
+
+func buildErr(baseline, candidate schema.ReportV01) (Diff, error) {
+	return Build(
+		EvidenceFromReport(baseline, "base.json", "baseline"),
+		EvidenceFromReport(candidate, "cand.json", "candidate"),
+		time.Unix(0, 0).UTC().Format(time.RFC3339))
 }
 
 func onlyCell(t *testing.T, d Diff) Cell {
@@ -134,7 +172,7 @@ func TestComparisonTable(t *testing.T) {
 			if tc.candidate != nil {
 				candTargets = append(candTargets, *tc.candidate)
 			}
-			d := build(t, report(true, baseTargets...), report(true, candTargets...))
+			d := build(t, report(baseTargets...), report(candTargets...))
 			cell := cellFor(t, d, "k")
 			if cell.Classification != tc.want {
 				t.Errorf("classification: want %s, got %s (%s)", tc.want, cell.Classification, cell.Reason)
@@ -161,7 +199,7 @@ func TestIncompleteBaselineCanNeverManufactureARegression(t *testing.T) {
 		{ProfileID: "k", Required: true, Status: "pass"}, // no verdict recorded at all
 	}
 	for _, base := range unproven {
-		d := build(t, report(false, base), report(true, target("k", I, true)))
+		d := build(t, report(base), report(target("k", I, true)))
 		cell := onlyCell(t, d)
 		if cell.Classification == NewRegression {
 			t.Fatalf("baseline %q/%v produced NEW_REGRESSION from an unproven baseline",
@@ -180,12 +218,12 @@ func TestIncompleteBaselineCanNeverManufactureARegression(t *testing.T) {
 // The mirror property: a proven required regression must survive noise.
 func TestProvenRequiredRegressionSurvivesUnrelatedNoise(t *testing.T) {
 	C, I := schema.VerdictCompatible, schema.VerdictIncompatible
-	baseline := report(true,
+	baseline := report(
 		target("gating", C, true),
 		target("flaky-optional", C, false),
 		target("also-required", C, true),
 	)
-	candidate := report(false,
+	candidate := report(
 		target("gating", I, true),                                 // the real regression
 		target("flaky-optional", schema.VerdictInfraError, false), // optional noise
 		target("also-required", schema.VerdictInfraError, true),   // required noise
@@ -208,10 +246,10 @@ func TestProvenRequiredRegressionSurvivesUnrelatedNoise(t *testing.T) {
 
 func TestOrderIndependence(t *testing.T) {
 	C, I := schema.VerdictCompatible, schema.VerdictIncompatible
-	a := report(true, target("a", C, true), target("b", I, true), target("c", C, false))
-	bRep := report(true, target("c", C, false), target("a", I, true), target("b", I, true))
-	shuffled := report(true, target("b", I, true), target("c", C, false), target("a", C, true))
-	shuffledCand := report(true, target("b", I, true), target("a", I, true), target("c", C, false))
+	a := report(target("a", C, true), target("b", I, true), target("c", C, false))
+	bRep := report(target("c", C, false), target("a", I, true), target("b", I, true))
+	shuffled := report(target("b", I, true), target("c", C, false), target("a", C, true))
+	shuffledCand := report(target("b", I, true), target("a", I, true), target("c", C, false))
 
 	d1 := build(t, a, bRep)
 	d2 := build(t, shuffled, shuffledCand)
@@ -228,9 +266,9 @@ func TestOrderIndependence(t *testing.T) {
 
 func TestLoaderContractChangeMakesEveryCellInconclusive(t *testing.T) {
 	C := schema.VerdictCompatible
-	baseline := report(true, target("k", C, true))
+	baseline := report(target("k", C, true))
 	baseline.Validator = &schema.BinaryIdentity{SHA256: "validator"}
-	candidate := report(true, target("k", C, true))
+	candidate := report(target("k", C, true))
 	candidate.Command = &schema.CommandInfo{InvocationSHA256: "inv"}
 
 	d := build(t, baseline, candidate)
@@ -247,7 +285,7 @@ func TestChangedObligationIsInconclusive(t *testing.T) {
 	base := target("k", C, true)
 	cand := target("k", C, true)
 	cand.Environment.RequestedKernelFamily = "6.1" // the profile now promises a different series
-	d := build(t, report(true, base), report(true, cand))
+	d := build(t, report(base), report(cand))
 	cell := onlyCell(t, d)
 	if cell.Classification != Inconclusive {
 		t.Fatalf("a profile that changed which kernel it claims is a different promise; got %s", cell.Classification)
@@ -262,7 +300,7 @@ func TestRequirednessChangeIsNotLikeForLike(t *testing.T) {
 	C, I := schema.VerdictCompatible, schema.VerdictIncompatible
 
 	t.Run("demotion cannot launder a regression into an optional finding", func(t *testing.T) {
-		d := build(t, report(true, target("k", C, true)), report(true, target("k", I, false)))
+		d := build(t, report(target("k", C, true)), report(target("k", I, false)))
 		cell := onlyCell(t, d)
 
 		if cell.Classification == NewRegression && !cell.Required {
@@ -289,7 +327,7 @@ func TestRequirednessChangeIsNotLikeForLike(t *testing.T) {
 		// The mirror direction. Whether a candidate "regressed" against a
 		// promise that did not exist at baseline is not something this evidence
 		// settles, so it is not reasoned about asymmetrically.
-		d := build(t, report(true, target("k", C, false)), report(true, target("k", I, true)))
+		d := build(t, report(target("k", C, false)), report(target("k", I, true)))
 		cell := onlyCell(t, d)
 		if cell.Classification != Inconclusive {
 			t.Fatalf("want %s, got %s", Inconclusive, cell.Classification)
@@ -301,7 +339,7 @@ func TestRequirednessChangeIsNotLikeForLike(t *testing.T) {
 
 	t.Run("unchanged requiredness still compares normally", func(t *testing.T) {
 		for _, req := range []bool{true, false} {
-			d := build(t, report(true, target("k", C, req)), report(true, target("k", I, req)))
+			d := build(t, report(target("k", C, req)), report(target("k", I, req)))
 			cell := onlyCell(t, d)
 			if cell.Classification != NewRegression {
 				t.Fatalf("required=%t: want %s, got %s", req, NewRegression, cell.Classification)
@@ -317,11 +355,11 @@ func TestRequirednessChangeIsNotLikeForLike(t *testing.T) {
 // these was previously tolerated and produced a diff that looked conclusive.
 func TestUnusableComparisonKeysFailClosed(t *testing.T) {
 	C := schema.VerdictCompatible
-	good := report(true, target("k", C, true))
+	good := report(target("k", C, true))
 
-	dup := report(true, target("k", C, true), target("k", schema.VerdictIncompatible, true))
-	blank := report(true, target("k", C, true), target("   ", C, true))
-	empty := report(true)
+	dup := report(target("k", C, true), target("k", schema.VerdictIncompatible, true))
+	blank := report(target("k", C, true), target("   ", C, true))
+	empty := report()
 
 	for _, tc := range []struct {
 		name                string
@@ -336,7 +374,7 @@ func TestUnusableComparisonKeysFailClosed(t *testing.T) {
 		{"zero targets in candidate", good, empty, "no targets"},
 	} {
 		t.Run(tc.name, func(t *testing.T) {
-			d, err := Build(tc.baseline, tc.candidate, "b", "c", "now")
+			d, err := buildErr(tc.baseline, tc.candidate)
 			if err == nil {
 				t.Fatalf("expected a refusal, got a diff with %d cells", len(d.Cells))
 			}
@@ -351,7 +389,7 @@ func TestUnusableComparisonKeysFailClosed(t *testing.T) {
 	}
 
 	// A duplicate must never be resolved by silently keeping one of them.
-	d, err := Build(dup, good, "b", "c", "now")
+	d, err := buildErr(dup, good)
 	if err == nil {
 		for i := range d.Cells {
 			if d.Cells[i].ProfileID == "k" {
@@ -377,9 +415,9 @@ func TestUnusableEvidenceReachesExitOneThroughCompare(t *testing.T) {
 		return p
 	}
 	C := schema.VerdictCompatible
-	good := write("good.json", report(true, target("k", C, true)))
-	dup := write("dup.json", report(true, target("k", C, true), target("k", C, true)))
-	empty := write("empty.json", report(true))
+	good := write("good.json", report(target("k", C, true)))
+	dup := write("dup.json", report(target("k", C, true), target("k", C, true)))
+	empty := write("empty.json", report())
 
 	for _, bad := range []string{dup, empty} {
 		if _, err := Compare(bad, good, time.Now()); err == nil {
@@ -392,7 +430,7 @@ func TestUnusableEvidenceReachesExitOneThroughCompare(t *testing.T) {
 }
 
 func TestUnsupportedSchemaFailsClosed(t *testing.T) {
-	good := report(true, target("k", schema.VerdictCompatible, true))
+	good := report(target("k", schema.VerdictCompatible, true))
 	for _, bad := range []string{"", "v0.2", "v1.0", "nonsense"} {
 		other := good
 		other.SchemaVersion = bad
@@ -411,7 +449,7 @@ func TestUnsupportedSchemaFailsClosed(t *testing.T) {
 func TestMalformedAndMissingEvidenceFailClosed(t *testing.T) {
 	dir := t.TempDir()
 	good := filepath.Join(dir, "good.json")
-	blob, _ := json.Marshal(report(true, target("k", schema.VerdictCompatible, true)))
+	blob, _ := json.Marshal(report(target("k", schema.VerdictCompatible, true)))
 	if err := os.WriteFile(good, blob, 0o600); err != nil {
 		t.Fatal(err)
 	}
@@ -433,8 +471,13 @@ func TestMalformedAndMissingEvidenceFailClosed(t *testing.T) {
 }
 
 func TestDiffJSONIsVersionedAndSelfDescribing(t *testing.T) {
-	d := build(t, report(true, target("k", schema.VerdictCompatible, true)),
-		report(false, target("k", schema.VerdictIncompatible, true)))
+	// The candidate is genuinely incomplete: an optional target produced no
+	// compatibility answer, which is what summary.complete records.
+	d := build(t, report(target("k", schema.VerdictCompatible, true)),
+		report(
+			target("k", schema.VerdictIncompatible, true),
+			target("optional-vm", schema.VerdictInfraError, false),
+		))
 	blob, err := json.Marshal(d)
 	if err != nil {
 		t.Fatal(err)
@@ -461,7 +504,7 @@ func TestDiffJSONIsVersionedAndSelfDescribing(t *testing.T) {
 // a file nobody can vouch for.
 func TestTrailingDataAfterTheReportIsRefused(t *testing.T) {
 	dir := t.TempDir()
-	valid, err := json.Marshal(report(true, target("k", schema.VerdictCompatible, true)))
+	valid, err := json.Marshal(report(target("k", schema.VerdictCompatible, true)))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/regressiondiff/diff_test.go
+++ b/internal/regressiondiff/diff_test.go
@@ -3,8 +3,10 @@ package regressiondiff
 import (
 	"bytes"
 	"encoding/json"
+	"errors"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
@@ -55,7 +57,11 @@ func report(complete bool, targets ...schema.Target) schema.ReportV01 {
 
 func build(t *testing.T, baseline, candidate schema.ReportV01) Diff {
 	t.Helper()
-	return Build(baseline, candidate, "base.json", "cand.json", time.Unix(0, 0).UTC().Format(time.RFC3339))
+	d, err := Build(baseline, candidate, "base.json", "cand.json", time.Unix(0, 0).UTC().Format(time.RFC3339))
+	if err != nil {
+		t.Fatalf("build: %v", err)
+	}
+	return d
 }
 
 func onlyCell(t *testing.T, d Diff) Cell {
@@ -64,6 +70,17 @@ func onlyCell(t *testing.T, d Diff) Cell {
 		t.Fatalf("expected exactly one cell, got %d", len(d.Cells))
 	}
 	return d.Cells[0]
+}
+
+func cellFor(t *testing.T, d Diff, profileID string) Cell {
+	t.Helper()
+	for i := range d.Cells {
+		if d.Cells[i].ProfileID == profileID {
+			return d.Cells[i]
+		}
+	}
+	t.Fatalf("no cell for %q in %+v", profileID, d.Cells)
+	return Cell{}
 }
 
 // The comparison table. Each row is a release decision that must differ.
@@ -105,7 +122,12 @@ func TestComparisonTable(t *testing.T) {
 
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {
-			var baseTargets, candTargets []schema.Target
+			// Every report carries a shared, unchanging anchor cell: a report
+			// with no targets is now rejected outright, and the anchor keeps
+			// coverage-add/remove rows expressible.
+			anchor := target("anchor", C, true)
+			baseTargets := []schema.Target{anchor}
+			candTargets := []schema.Target{anchor}
 			if tc.baseline != nil {
 				baseTargets = append(baseTargets, *tc.baseline)
 			}
@@ -113,7 +135,7 @@ func TestComparisonTable(t *testing.T) {
 				candTargets = append(candTargets, *tc.candidate)
 			}
 			d := build(t, report(true, baseTargets...), report(true, candTargets...))
-			cell := onlyCell(t, d)
+			cell := cellFor(t, d, "k")
 			if cell.Classification != tc.want {
 				t.Errorf("classification: want %s, got %s (%s)", tc.want, cell.Classification, cell.Reason)
 			}
@@ -232,19 +254,140 @@ func TestChangedObligationIsInconclusive(t *testing.T) {
 	}
 }
 
-func TestRequiredFlagFollowsTheCandidateAndRecordsChanges(t *testing.T) {
+// Replaces an earlier test that asserted "the candidate defines the current
+// support claim". That rule let a release dodge its own gate: flip a profile to
+// `required: false` in the candidate and a regression on an environment the
+// baseline promised became a non-gating optional finding.
+func TestRequirednessChangeIsNotLikeForLike(t *testing.T) {
 	C, I := schema.VerdictCompatible, schema.VerdictIncompatible
-	// Demoting a required profile to optional must be visible.
-	d := build(t, report(true, target("k", C, true)), report(true, target("k", I, false)))
-	cell := onlyCell(t, d)
-	if !cell.RequiredChanged {
-		t.Fatal("a required->optional demotion must be recorded")
+
+	t.Run("demotion cannot launder a regression into an optional finding", func(t *testing.T) {
+		d := build(t, report(true, target("k", C, true)), report(true, target("k", I, false)))
+		cell := onlyCell(t, d)
+
+		if cell.Classification == NewRegression && !cell.Required {
+			t.Fatal("a required->optional demotion turned a gating regression into an optional one")
+		}
+		if cell.Classification != Inconclusive {
+			t.Fatalf("a support-contract change is not like-for-like evidence; want %s, got %s", Inconclusive, cell.Classification)
+		}
+		if !cell.Required {
+			t.Fatal("an obligation either side treated as required must still gate")
+		}
+		if !cell.RequiredChanged {
+			t.Fatal("the requiredness change must be recorded")
+		}
+		if d.Summary.Result != ResultInconclusive || ExitCode(d) != ExitInconclusive {
+			t.Fatalf("want %s/exit %d, got %s/exit %d", ResultInconclusive, ExitInconclusive, d.Summary.Result, ExitCode(d))
+		}
+		if d.Summary.NewOptionalRegressions != 0 {
+			t.Fatalf("the demotion must not be counted as an optional regression: %+v", d.Summary)
+		}
+	})
+
+	t.Run("promotion is equally not like-for-like", func(t *testing.T) {
+		// The mirror direction. Whether a candidate "regressed" against a
+		// promise that did not exist at baseline is not something this evidence
+		// settles, so it is not reasoned about asymmetrically.
+		d := build(t, report(true, target("k", C, false)), report(true, target("k", I, true)))
+		cell := onlyCell(t, d)
+		if cell.Classification != Inconclusive {
+			t.Fatalf("want %s, got %s", Inconclusive, cell.Classification)
+		}
+		if !cell.Required || ExitCode(d) != ExitInconclusive {
+			t.Fatalf("a newly-required obligation must gate: required=%t exit=%d", cell.Required, ExitCode(d))
+		}
+	})
+
+	t.Run("unchanged requiredness still compares normally", func(t *testing.T) {
+		for _, req := range []bool{true, false} {
+			d := build(t, report(true, target("k", C, req)), report(true, target("k", I, req)))
+			cell := onlyCell(t, d)
+			if cell.Classification != NewRegression {
+				t.Fatalf("required=%t: want %s, got %s", req, NewRegression, cell.Classification)
+			}
+			if cell.RequiredChanged {
+				t.Fatalf("required=%t: nothing changed", req)
+			}
+		}
+	})
+}
+
+// Comparison keys must be trustworthy before anything is compared. Each of
+// these was previously tolerated and produced a diff that looked conclusive.
+func TestUnusableComparisonKeysFailClosed(t *testing.T) {
+	C := schema.VerdictCompatible
+	good := report(true, target("k", C, true))
+
+	dup := report(true, target("k", C, true), target("k", schema.VerdictIncompatible, true))
+	blank := report(true, target("k", C, true), target("   ", C, true))
+	empty := report(true)
+
+	for _, tc := range []struct {
+		name                string
+		baseline, candidate schema.ReportV01
+		wantSubstr          string
+	}{
+		{"duplicate profile_id in baseline", dup, good, "ambiguous"},
+		{"duplicate profile_id in candidate", good, dup, "ambiguous"},
+		{"blank profile_id in baseline", blank, good, "empty profile_id"},
+		{"blank profile_id in candidate", good, blank, "empty profile_id"},
+		{"zero targets in baseline", empty, good, "no targets"},
+		{"zero targets in candidate", good, empty, "no targets"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d, err := Build(tc.baseline, tc.candidate, "b", "c", "now")
+			if err == nil {
+				t.Fatalf("expected a refusal, got a diff with %d cells", len(d.Cells))
+			}
+			if !strings.Contains(err.Error(), tc.wantSubstr) {
+				t.Fatalf("error should say why: want %q in %q", tc.wantSubstr, err.Error())
+			}
+			var invalid *InvalidEvidenceError
+			if !errors.As(err, &invalid) {
+				t.Fatalf("want InvalidEvidenceError, got %T", err)
+			}
+		})
 	}
-	if cell.Required {
-		t.Fatal("the candidate defines the current support claim")
+
+	// A duplicate must never be resolved by silently keeping one of them.
+	d, err := Build(dup, good, "b", "c", "now")
+	if err == nil {
+		for i := range d.Cells {
+			if d.Cells[i].ProfileID == "k" {
+				t.Fatal("a duplicated profile_id was resolved by picking a winner")
+			}
+		}
 	}
-	if d.Summary.NewOptionalRegressions != 1 {
-		t.Fatalf("expected the regression to be counted as optional: %+v", d.Summary)
+}
+
+// The CLI must map every unusable-evidence refusal to exit 1 -- an inability to
+// compare, never a verdict on the candidate.
+func TestUnusableEvidenceReachesExitOneThroughCompare(t *testing.T) {
+	dir := t.TempDir()
+	write := func(name string, r schema.ReportV01) string {
+		blob, err := json.Marshal(r)
+		if err != nil {
+			t.Fatal(err)
+		}
+		p := filepath.Join(dir, name)
+		if err := os.WriteFile(p, blob, 0o600); err != nil {
+			t.Fatal(err)
+		}
+		return p
+	}
+	C := schema.VerdictCompatible
+	good := write("good.json", report(true, target("k", C, true)))
+	dup := write("dup.json", report(true, target("k", C, true), target("k", C, true)))
+	empty := write("empty.json", report(true))
+
+	for _, bad := range []string{dup, empty} {
+		if _, err := Compare(bad, good, time.Now()); err == nil {
+			t.Errorf("%s was accepted as a baseline", filepath.Base(bad))
+		}
+		if _, err := Compare(good, bad, time.Now()); err == nil {
+			t.Errorf("%s was accepted as a candidate", filepath.Base(bad))
+		}
 	}
 }
 

--- a/internal/regressiondiff/evidence.go
+++ b/internal/regressiondiff/evidence.go
@@ -1,0 +1,245 @@
+package regressiondiff
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/kernel-guard/bpfcompat/pkg/schema"
+)
+
+// maxEvidenceBytes bounds how much of a supplied file is read before anything
+// is validated. A release gate consumes CI artifacts that a pull request author
+// controls, and os.ReadFile on an attacker-sized file is an OOM before a single
+// check runs. The largest report this project has ever produced is ~60 KB (a
+// 30-target expanded matrix), so 32 MiB is roughly five hundred times the real
+// ceiling: it cannot reject genuine evidence, and it turns "exhaust the runner"
+// into "exit 1 with a reason".
+const maxEvidenceBytes = 32 << 20
+
+// maxJSONDepth bounds nesting while scanning for duplicate keys. Real reports
+// nest five deep. Without a limit, a file of ten thousand "[" characters would
+// recurse until the stack died -- a panic is not an acceptable answer to
+// malformed evidence, so depth is refused explicitly instead.
+const maxJSONDepth = 64
+
+// Evidence is one side's report plus the facts only its raw JSON can answer.
+//
+// The parsed struct cannot distinguish an absent `required` from `required:
+// false`: both deserialize to the Go zero value. That difference decides
+// whether a proven regression gates the release, so it is captured here at the
+// point where it still exists rather than inferred later.
+type Evidence struct {
+	Report schema.ReportV01
+	Path   string
+	Side   string
+
+	// requiredPresent is parallel to Report.Targets: true when that target
+	// actually carried a `required` field with a boolean value.
+	requiredPresent []bool
+}
+
+// EvidenceFromReport wraps an already-constructed report.
+//
+// A caller holding a schema.ReportV01 built in Go knows every target's
+// `required` value definitely -- absence is a JSON-level concept and cannot
+// arise here. Evidence read from a file must come through LoadEvidence, which
+// is the only path that sees the raw bytes.
+func EvidenceFromReport(r schema.ReportV01, path, side string) Evidence {
+	present := make([]bool, len(r.Targets))
+	for i := range present {
+		present[i] = true
+	}
+	return Evidence{Report: r, Path: path, Side: side, requiredPresent: present}
+}
+
+// LoadEvidence reads and validates one evidence file.
+//
+// Everything here is a question about a single report: is this file one
+// unambiguous JSON document, and does it contradict itself? Comparison
+// questions belong to Build. A file that fails any of it is refused rather than
+// partially trusted -- a release gate that guesses which of two values for the
+// same field was meant is not a gate.
+func LoadEvidence(path, side string) (Evidence, error) {
+	blob, err := readBounded(path)
+	if err != nil {
+		return Evidence{}, err
+	}
+
+	// Duplicate keys first: until this passes, no field's value is known, so
+	// there is nothing meaningful to validate.
+	if err := rejectDuplicateKeys(blob); err != nil {
+		return Evidence{}, &InvalidEvidenceError{Side: side, Reason: err.Error()}
+	}
+
+	var report schema.ReportV01
+	dec := json.NewDecoder(bytes.NewReader(blob))
+	if err := dec.Decode(&report); err != nil {
+		return Evidence{}, fmt.Errorf("parse report %s: %w", path, err)
+	}
+	// Decode stops after one JSON value and is happy to leave the rest of the
+	// file unread. Evidence with anything after the report -- a second value, a
+	// truncated append, stray bytes -- is not evidence we can vouch for, and
+	// comparing only its first value would look entirely successful.
+	if err := requireEOF(dec); err != nil {
+		return Evidence{}, fmt.Errorf("parse report %s: %w", path, err)
+	}
+
+	ev := Evidence{
+		Report:          report,
+		Path:            path,
+		Side:            side,
+		requiredPresent: requiredPresence(blob, len(report.Targets)),
+	}
+	if err := Validate(report, side); err != nil {
+		return Evidence{}, err
+	}
+	if err := ev.validatePresence(); err != nil {
+		return Evidence{}, err
+	}
+	return ev, nil
+}
+
+// readBounded reads at most maxEvidenceBytes, and reports a file larger than
+// that as an error instead of consuming it.
+func readBounded(path string) ([]byte, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, fmt.Errorf("read report %s: %w", path, err)
+	}
+	defer f.Close() //nolint:errcheck // read-only
+	blob, err := io.ReadAll(io.LimitReader(f, maxEvidenceBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read report %s: %w", path, err)
+	}
+	if len(blob) > maxEvidenceBytes {
+		return nil, fmt.Errorf("read report %s: file is larger than the %d MiB evidence limit; bpfcompat reports are kilobytes, so this is not one",
+			path, maxEvidenceBytes>>20)
+	}
+	return blob, nil
+}
+
+// requiredPresence records, for each target, whether `required` was actually
+// written as a boolean. `required: null` counts as absent: it carries no more
+// information than omitting the key.
+func requiredPresence(blob []byte, targets int) []bool {
+	var shallow struct {
+		Targets []struct {
+			Required *bool `json:"required"`
+		} `json:"targets"`
+	}
+	present := make([]bool, targets)
+	if err := json.Unmarshal(blob, &shallow); err != nil {
+		return present
+	}
+	for i := range present {
+		if i < len(shallow.Targets) && shallow.Targets[i].Required != nil {
+			present[i] = true
+		}
+	}
+	return present
+}
+
+// validatePresence refuses evidence that never states a target's requiredness.
+//
+// `required` decides whether a proven regression gates the release. Absent, it
+// deserializes to false, which silently reclassifies a NEW_REGRESSION as an
+// optional finding and lets the run exit 0. Deleting a field is not a way to
+// discover that an obligation was never required -- it is a way to lose the
+// support contract, and the gate says so.
+func (e Evidence) validatePresence() error {
+	for i := range e.Report.Targets {
+		if i < len(e.requiredPresent) && e.requiredPresent[i] {
+			continue
+		}
+		return &InvalidEvidenceError{Side: e.Side, Reason: fmt.Sprintf(
+			"target %d (%s) does not record `required`, so whether this obligation gates a release is unknown",
+			i, strings.TrimSpace(e.Report.Targets[i].ProfileID))}
+	}
+	return nil
+}
+
+// rejectDuplicateKeys refuses a document containing the same key twice in one
+// object, at any depth.
+//
+// encoding/json accepts duplicates and keeps the last value, so
+// `"verdict":"INCOMPATIBLE","verdict":"COMPATIBLE"` parses as COMPATIBLE while
+// a human reading the file sees a failure. Which value a release decision was
+// made from must not depend on a parser's choice, and there is no reading of a
+// duplicated field that is evidence of anything. The rule is deliberately
+// blanket rather than a list of fields that matter: an exemption list is a
+// place for the next contract field to be forgotten.
+func rejectDuplicateKeys(blob []byte) error {
+	dec := json.NewDecoder(bytes.NewReader(blob))
+	dec.UseNumber()
+	err := scanForDuplicateKeys(dec, "", 0)
+	if errors.Is(err, errMalformedJSON) {
+		// Not this function's finding to report: the real decode below fails on
+		// the same bytes and says where. One fault, one error message.
+		return nil
+	}
+	return err
+}
+
+// errMalformedJSON stops the scan the moment the token stream stops making
+// sense. It must be propagated rather than swallowed: after a token error the
+// decoder stays in that error state, and json.Decoder.More keeps answering
+// true, so a loop that continues past it never terminates. Fuzzing found
+// exactly that -- `"kernel_family_match":ntll` hung the process rather than
+// being refused.
+var errMalformedJSON = errors.New("malformed JSON")
+
+func scanForDuplicateKeys(dec *json.Decoder, path string, depth int) error {
+	if depth > maxJSONDepth {
+		return fmt.Errorf("JSON nesting deeper than %d is refused; a bpfcompat report is not shaped like this", maxJSONDepth)
+	}
+	tok, err := dec.Token()
+	if err != nil {
+		return errMalformedJSON
+	}
+	delim, ok := tok.(json.Delim)
+	if !ok {
+		return nil
+	}
+	switch delim {
+	case '{':
+		seen := make(map[string]struct{})
+		for dec.More() {
+			keyTok, err := dec.Token()
+			if err != nil {
+				return errMalformedJSON
+			}
+			key, ok := keyTok.(string)
+			if !ok {
+				return errMalformedJSON
+			}
+			child := key
+			if path != "" {
+				child = path + "." + key
+			}
+			if _, dup := seen[key]; dup {
+				return fmt.Errorf("the JSON key %q appears twice in the same object; which value the release decision would be made from is ambiguous", child)
+			}
+			seen[key] = struct{}{}
+			if err := scanForDuplicateKeys(dec, child, depth+1); err != nil {
+				return err
+			}
+		}
+	case '[':
+		for i := 0; dec.More(); i++ {
+			if err := scanForDuplicateKeys(dec, fmt.Sprintf("%s[%d]", path, i), depth+1); err != nil {
+				return err
+			}
+		}
+	}
+	// Consume the closing delimiter. A truncated document ends the token
+	// stream here, which the real decode reports.
+	if _, err := dec.Token(); err != nil {
+		return errMalformedJSON
+	}
+	return nil
+}

--- a/internal/regressiondiff/fuzz_test.go
+++ b/internal/regressiondiff/fuzz_test.go
@@ -1,0 +1,359 @@
+package regressiondiff
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"math/rand"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kernel-guard/bpfcompat/pkg/schema"
+)
+
+// Property and fuzz coverage for the evidence trust boundary. Hand-picked cases
+// prove the failures we thought of; these prove the shape of the contract
+// itself, over inputs nobody chose.
+//
+// Both fuzz targets are bounded and deterministic in CI: `go test` runs their
+// seed corpus only, and every seed is committed here rather than generated, so
+// no run can be flaky. `go test -fuzz` explores further on demand.
+
+// exitZeroRequiresEstablishedRequiredEvidence is the whole gate in one
+// function, and the postcondition every property below checks.
+//
+// Exit 0 claims that no required environment the baseline supported is broken.
+// That claim is only honest if, for every obligation either side treated as
+// required, the candidate positively settled it -- and, where the baseline also
+// tested it, the baseline settled it too. Anything else is an absence, and an
+// absence must reach exit 1.
+func exitZeroRequiresEstablishedRequiredEvidence(t *testing.T, d Diff, context string) {
+	t.Helper()
+	if ExitCode(d) != ExitNoRegressions {
+		return
+	}
+	for i := range d.Cells {
+		c := &d.Cells[i]
+		if !c.Required {
+			continue
+		}
+		if !conclusive(c.Candidate) {
+			t.Fatalf("%s: exit 0 with required obligation %q the candidate never established (%s: %s)",
+				context, c.ProfileID, c.Classification, c.Reason)
+		}
+		if c.Baseline.Present && !conclusive(c.Baseline) {
+			t.Fatalf("%s: exit 0 with required obligation %q whose baseline never established it (%s: %s)",
+				context, c.ProfileID, c.Classification, c.Reason)
+		}
+	}
+}
+
+// requiredRegressionsAreProven is invariant C: the only statement this tool
+// makes about someone's software must rest on two established results and an
+// unchanged obligation.
+func requiredRegressionsAreProven(t *testing.T, d Diff, context string) {
+	t.Helper()
+	for i := range d.Cells {
+		c := &d.Cells[i]
+		if c.Classification != NewRegression {
+			continue
+		}
+		if !conclusive(c.Baseline) || c.Baseline.Verdict != schema.VerdictCompatible {
+			t.Fatalf("%s: NEW_REGRESSION on %q without a baseline that proved support (%+v)", context, c.ProfileID, c.Baseline)
+		}
+		if !conclusive(c.Candidate) || c.Candidate.Verdict != schema.VerdictIncompatible {
+			t.Fatalf("%s: NEW_REGRESSION on %q without a candidate that proved breakage (%+v)", context, c.ProfileID, c.Candidate)
+		}
+		if c.RequiredChanged {
+			t.Fatalf("%s: NEW_REGRESSION on %q across a support-contract change", context, c.ProfileID)
+		}
+	}
+}
+
+func writeTemp(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// Invariant A and B over arbitrary bytes: no input panics, and anything that
+// survives validation really does satisfy the comparison-key rules.
+func FuzzLoadEvidence(f *testing.F) {
+	valid := `{"schema_version":"v0.1","run":{"id":"r1"},"targets":[{"profile_id":"k","required":true,"status":"pass","verdict":"COMPATIBLE","environment":{"requested_kernel_family":"5.15","observed_kernel":"5.15.0-1","kernel_family_match":true}}],"summary":{"status":"pass","verdict":"COMPATIBLE","complete":true}}`
+	for _, seed := range []string{
+		valid,
+		``,
+		`{`,
+		`null`,
+		`[]`,
+		`"a string"`,
+		`{"schema_version":"v0.1"}`,
+		`{"schema_version":"v0.1","targets":[]}`,
+		valid + valid,
+		valid + "\n\n\t",
+		strings.Replace(valid, `"verdict":"COMPATIBLE"`, `"verdict":"INCOMPATIBLE","verdict":"COMPATIBLE"`, 1),
+		strings.Replace(valid, `"required":true,`, ``, 1),
+		strings.Replace(valid, `"required":true`, `"required":null`, 1),
+		strings.Replace(valid, `"profile_id":"k"`, `"profile_id":"  "`, 1),
+		strings.Replace(valid, `"status":"pass","verdict":"COMPATIBLE"`, `"status":"fail","verdict":"COMPATIBLE"`, 1),
+		strings.Replace(valid, `"kernel_family_match":true`, `"kernel_family_match":null`, 1),
+		strings.Repeat("[", 200) + strings.Repeat("]", 200),
+		"\x00\x01\x02",
+	} {
+		f.Add(seed)
+	}
+
+	f.Fuzz(func(t *testing.T, blob string) {
+		dir := t.TempDir()
+		path := writeTemp(t, dir, "evidence.json", blob)
+
+		ev, err := LoadEvidence(path, "candidate") // must not panic, whatever this is
+		if err != nil {
+			return
+		}
+		// Whatever survived must satisfy every key rule, because the rest of
+		// the differ is written assuming it does.
+		if len(ev.Report.Targets) == 0 {
+			t.Fatal("accepted a report with no targets")
+		}
+		seen := map[string]bool{}
+		for i := range ev.Report.Targets {
+			id := strings.TrimSpace(ev.Report.Targets[i].ProfileID)
+			if id == "" {
+				t.Fatalf("accepted an unidentifiable obligation at target %d", i)
+			}
+			if seen[id] {
+				t.Fatalf("accepted a duplicated profile_id %q", id)
+			}
+			seen[id] = true
+			if i >= len(ev.requiredPresent) || !ev.requiredPresent[i] {
+				t.Fatalf("accepted target %d without a stated `required`", i)
+			}
+		}
+	})
+}
+
+// Invariants B and C over arbitrary pairs: whatever two files are handed in,
+// exit 0 is only ever reached over established required evidence.
+func FuzzCompareNeverGreensUnestablishedEvidence(f *testing.F) {
+	mk := func(runID, verdict, status string, required bool, env string) string {
+		return fmt.Sprintf(`{"schema_version":"v0.1","run":{"id":%q},"targets":[{"profile_id":"k","required":%t,"status":%q,"verdict":%q%s}],"summary":{}}`,
+			runID, required, status, verdict, env)
+	}
+	goodEnv := `,"environment":{"requested_kernel_family":"5.15","observed_kernel":"5.15.0-1","kernel_family_match":true}`
+	badEnv := `,"environment":{"requested_kernel_family":"5.15","observed_kernel":"6.1.0","kernel_family_match":false}`
+
+	f.Add(mk("a", "COMPATIBLE", "pass", true, goodEnv), mk("b", "COMPATIBLE", "pass", true, goodEnv))
+	f.Add(mk("a", "COMPATIBLE", "pass", true, goodEnv), mk("b", "INCOMPATIBLE", "fail", true, goodEnv))
+	f.Add(mk("a", "COMPATIBLE", "pass", true, goodEnv), mk("b", "COMPATIBLE", "pass", true, ""))
+	f.Add(mk("a", "COMPATIBLE", "pass", true, ""), mk("b", "COMPATIBLE", "pass", true, ""))
+	f.Add(mk("a", "COMPATIBLE", "pass", true, badEnv), mk("b", "COMPATIBLE", "pass", true, goodEnv))
+	f.Add(mk("a", "INFRA_ERROR", "infra_error", true, goodEnv), mk("b", "INCOMPATIBLE", "fail", true, goodEnv))
+	f.Add(mk("a", "COMPATIBLE", "pass", true, goodEnv), mk("a", "COMPATIBLE", "pass", true, goodEnv))
+	f.Add(`{}`, `{}`)
+	f.Add(``, mk("b", "COMPATIBLE", "pass", true, goodEnv))
+
+	f.Fuzz(func(t *testing.T, baseline, candidate string) {
+		dir := t.TempDir()
+		bp := writeTemp(t, dir, "baseline.json", baseline)
+		cp := writeTemp(t, dir, "candidate.json", candidate)
+
+		d, err := Compare(bp, cp, time.Unix(0, 0)) // must not panic
+		if err != nil {
+			return
+		}
+		exitZeroRequiresEstablishedRequiredEvidence(t, d, "fuzz")
+		requiredRegressionsAreProven(t, d, "fuzz")
+
+		// Rendering must survive anything the comparison accepted: a release
+		// gate that panics while writing its own report has still failed.
+		_ = Markdown(d)
+		if _, err := json.Marshal(d); err != nil {
+			t.Fatalf("diff could not be serialised: %v", err)
+		}
+	})
+}
+
+// Invariant D: the diff is a function of the evidence, not of the order rows
+// happen to appear in.
+func TestReorderingTargetsCannotChangeTheDiff(t *testing.T) {
+	C, I, E := schema.VerdictCompatible, schema.VerdictIncompatible, schema.VerdictInfraError
+	baseTargets := []schema.Target{
+		target("a", C, true), target("b", I, true), target("c", C, false),
+		target("d", E, false), mismatched(target("e", C, true)),
+	}
+	candTargets := []schema.Target{
+		target("a", I, true), target("b", I, true), target("c", C, false),
+		target("d", C, false), target("e", C, true),
+	}
+
+	want := build(t, report(baseTargets...), report(candTargets...))
+	wantJSON, err := json.Marshal(want.Cells)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	rng := rand.New(rand.NewSource(20260910)) // fixed seed: deterministic in CI
+	for i := 0; i < 50; i++ {
+		shuffledBase := append([]schema.Target(nil), baseTargets...)
+		shuffledCand := append([]schema.Target(nil), candTargets...)
+		rng.Shuffle(len(shuffledBase), func(x, y int) {
+			shuffledBase[x], shuffledBase[y] = shuffledBase[y], shuffledBase[x]
+		})
+		rng.Shuffle(len(shuffledCand), func(x, y int) {
+			shuffledCand[x], shuffledCand[y] = shuffledCand[y], shuffledCand[x]
+		})
+		got := build(t, report(shuffledBase...), report(shuffledCand...))
+		gotJSON, err := json.Marshal(got.Cells)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(gotJSON, wantJSON) {
+			t.Fatalf("permutation %d changed the diff:\n%s\n%s", i, wantJSON, gotJSON)
+		}
+		// Compared as JSON: Summary holds *bool fields, and comparing the
+		// structs directly would compare pointer identity rather than the
+		// coverage flags they carry.
+		gotSummary, err := json.Marshal(got.Summary)
+		if err != nil {
+			t.Fatal(err)
+		}
+		wantSummary, err := json.Marshal(want.Summary)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(gotSummary, wantSummary) {
+			t.Fatalf("permutation %d changed the summary:\n%s\n%s", i, wantSummary, gotSummary)
+		}
+	}
+}
+
+// Invariant E: a proven required regression cannot be buried under noise,
+// however much of it arrives.
+func TestNoiseCannotHideAProvenRequiredRegression(t *testing.T) {
+	C, I, E, U := schema.VerdictCompatible, schema.VerdictIncompatible,
+		schema.VerdictInfraError, schema.VerdictUnsupported
+
+	noise := []struct {
+		name       string
+		base, cand *schema.Target
+	}{
+		{"optional infra failure", p(target("n1", C, false)), p(target("n1", E, false))},
+		{"optional unsupported", p(target("n2", C, false)), p(target("n2", U, false))},
+		{"optional regression", p(target("n3", C, false)), p(target("n3", I, false))},
+		{"required infra failure", p(target("n4", C, true)), p(target("n4", E, true))},
+		{"required coverage removed", p(target("n5", C, true)), nil},
+		{"coverage added", nil, p(target("n6", C, true))},
+		{"requiredness churn", p(target("n7", C, true)), p(target("n7", C, false))},
+		{"environment mismatch", p(target("n8", C, true)), p(mismatched(target("n8", C, true)))},
+		{"a fix elsewhere", p(target("n9", I, true)), p(target("n9", C, true))},
+		{"an existing limitation", p(target("n10", I, true)), p(target("n10", I, true))},
+	}
+
+	baseTargets := []schema.Target{target("gating", C, true)}
+	candTargets := []schema.Target{target("gating", I, true)}
+	for _, n := range noise {
+		if n.base != nil {
+			baseTargets = append(baseTargets, *n.base)
+		}
+		if n.cand != nil {
+			candTargets = append(candTargets, *n.cand)
+		}
+		d := build(t, report(baseTargets...), report(candTargets...))
+		if d.Summary.NewRequiredRegressions != 1 {
+			t.Fatalf("after adding %q: want 1 required regression, got %d", n.name, d.Summary.NewRequiredRegressions)
+		}
+		if d.Summary.Result != ResultRegressed || ExitCode(d) != ExitRegressed {
+			t.Fatalf("after adding %q: a proven regression was downgraded to %s (exit %d)", n.name, d.Summary.Result, ExitCode(d))
+		}
+		requiredRegressionsAreProven(t, d, "noise:"+n.name)
+	}
+}
+
+// Invariant F, in the direction that matters for a release gate: deleting
+// evidence never buys a green result. (It can legitimately narrow the claim --
+// a baseline that never tested an environment cannot have regressed on it --
+// so the property is stated as the contract exit 0 actually promises, not as a
+// blanket monotonicity that would be false.)
+func TestRemovingEvidenceNeverBuysAGreenResult(t *testing.T) {
+	C, I, E := schema.VerdictCompatible, schema.VerdictIncompatible, schema.VerdictInfraError
+
+	scenarios := map[string][2]schema.Target{
+		"proven regression":     {target("k", C, true), target("k", I, true)},
+		"unchanged compatible":  {target("k", C, true), target("k", C, true)},
+		"unproven baseline":     {target("k", E, true), target("k", I, true)},
+		"mismatched candidate":  {target("k", C, true), mismatched(target("k", C, true))},
+		"optional obligation":   {target("k", C, false), target("k", I, false)},
+		"existing incompatible": {target("k", I, true), target("k", I, true)},
+	}
+
+	// Each mutation deletes information from the raw JSON, which is what a
+	// truncating CI artifact step or a hand edit actually does.
+	deletions := []struct{ name, find, replace string }{
+		{"verdict deleted", `"verdict": "`, `"unused_verdict": "`},
+		{"status deleted", `"status": "`, `"unused_status": "`},
+		{"environment deleted", `"environment": {`, `"unused_environment": {`},
+		{"kernel_family_match deleted", `"kernel_family_match":`, `"unused_match":`},
+		{"observed kernel deleted", `"observed_kernel": "`, `"unused_observed": "`},
+		{"required deleted", `"required": true,`, ``},
+		{"summary verdict deleted", `"verdict": "COMPATIBLE",`, ``},
+		{"whole targets array emptied", `"targets": [`, `"unused_targets": [`},
+	}
+
+	for name, pair := range scenarios {
+		for _, side := range []string{"baseline", "candidate"} {
+			for _, del := range deletions {
+				t.Run(fmt.Sprintf("%s/%s/%s", name, side, del.name), func(t *testing.T) {
+					baseJSON := jsonOf(t, report(pair[0]))
+					candJSON := jsonOf(t, report(pair[1]))
+					if side == "baseline" {
+						baseJSON = strings.Replace(baseJSON, del.find, del.replace, 1)
+					} else {
+						candJSON = strings.Replace(candJSON, del.find, del.replace, 1)
+					}
+					d, exit, err := compareFiles(t, baseJSON, candJSON)
+					if err != nil {
+						return // refused: the strongest form of not-green
+					}
+					if exit == ExitNoRegressions {
+						exitZeroRequiresEstablishedRequiredEvidence(t, d, name+"/"+del.name)
+					}
+					requiredRegressionsAreProven(t, d, name+"/"+del.name)
+				})
+			}
+		}
+	}
+}
+
+// Adding optional, irrelevant fields must not change a release decision: a
+// report is judged on the evidence the contract names, not on its size.
+func TestIrrelevantNoiseDoesNotChangeTheDecision(t *testing.T) {
+	C, I := schema.VerdictCompatible, schema.VerdictIncompatible
+	baseJSON := jsonOf(t, report(target("k", C, true)))
+	candJSON := jsonOf(t, report(target("k", I, true)))
+
+	want, wantExit, err := compareFiles(t, baseJSON, candJSON)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	noisy := strings.Replace(candJSON, `"profile_id": "k",`,
+		`"profile_id": "k", "notes": ["a", "b"], "duration_ms": 1234, "qemu_command": "qemu -x -y", "serial_log": "/tmp/x.log",`, 1)
+	got, gotExit, err := compareFiles(t, baseJSON, noisy)
+	if err != nil {
+		t.Fatalf("optional fields must not make evidence unreadable: %v", err)
+	}
+	if gotExit != wantExit || got.Summary.Result != want.Summary.Result {
+		t.Fatalf("irrelevant fields changed the decision: %s/%d became %s/%d",
+			want.Summary.Result, wantExit, got.Summary.Result, gotExit)
+	}
+	if got.Summary.NewRequiredRegressions != 1 {
+		t.Fatalf("the regression was lost under noise: %+v", got.Summary)
+	}
+}

--- a/internal/regressiondiff/io.go
+++ b/internal/regressiondiff/io.go
@@ -40,8 +40,10 @@ func LoadReport(path string) (schema.ReportV01, error) {
 	return report, nil
 }
 
-// Compare loads both reports, validates their schemas and builds the diff. It
-// touches nothing but those two files: no database, no network, no service.
+// Compare loads both reports, validates their schemas and comparison keys, and
+// builds the diff. It touches nothing but those two files: no database, no
+// network, no service. Every failure here is an inability to compare, which the
+// caller reports as exit 1 and never as a verdict on the candidate.
 func Compare(baselinePath, candidatePath string, now time.Time) (Diff, error) {
 	baseline, err := LoadReport(baselinePath)
 	if err != nil {
@@ -56,7 +58,7 @@ func Compare(baselinePath, candidatePath string, now time.Time) (Diff, error) {
 	}
 	return Build(baseline, candidate,
 		absOrOriginal(baselinePath), absOrOriginal(candidatePath),
-		now.UTC().Format(time.RFC3339)), nil
+		now.UTC().Format(time.RFC3339))
 }
 
 // ExitCode maps the diff's overall result onto the process contract.

--- a/internal/regressiondiff/io.go
+++ b/internal/regressiondiff/io.go
@@ -1,7 +1,6 @@
 package regressiondiff
 
 import (
-	"bytes"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -27,28 +26,16 @@ const (
 	ExitRegressed     = 2
 )
 
-// LoadReport reads one evidence file. A file that is absent, not valid JSON, or
-// carrying anything after the report is an error rather than a partial report,
-// so neither a typo in a path nor a truncated or concatenated file can be
-// mistaken for "nothing regressed".
+// LoadReport reads one evidence file and returns the report alone. It is the
+// convenience wrapper around LoadEvidence for callers that only want the parsed
+// document; anything making a release decision must use LoadEvidence, which
+// keeps the presence facts the raw JSON carries.
 func LoadReport(path string) (schema.ReportV01, error) {
-	blob, err := os.ReadFile(path)
+	ev, err := LoadEvidence(path, "report")
 	if err != nil {
-		return schema.ReportV01{}, fmt.Errorf("read report %s: %w", path, err)
+		return schema.ReportV01{}, err
 	}
-	var report schema.ReportV01
-	dec := json.NewDecoder(bytes.NewReader(blob))
-	if err := dec.Decode(&report); err != nil {
-		return schema.ReportV01{}, fmt.Errorf("parse report %s: %w", path, err)
-	}
-	// Decode stops after one JSON value and is happy to leave the rest of the
-	// file unread. Evidence with anything after the report -- a second value, a
-	// truncated append, stray bytes -- is not evidence we can vouch for, and
-	// comparing only its first value would look entirely successful.
-	if err := requireEOF(dec); err != nil {
-		return schema.ReportV01{}, fmt.Errorf("parse report %s: %w", path, err)
-	}
-	return report, nil
+	return ev.Report, nil
 }
 
 func requireEOF(dec *json.Decoder) error {
@@ -68,20 +55,20 @@ func requireEOF(dec *json.Decoder) error {
 // network, no service. Every failure here is an inability to compare, which the
 // caller reports as exit 1 and never as a verdict on the candidate.
 func Compare(baselinePath, candidatePath string, now time.Time) (Diff, error) {
-	baseline, err := LoadReport(baselinePath)
+	baseline, err := LoadEvidence(baselinePath, "baseline")
 	if err != nil {
 		return Diff{}, err
 	}
-	candidate, err := LoadReport(candidatePath)
+	candidate, err := LoadEvidence(candidatePath, "candidate")
 	if err != nil {
 		return Diff{}, err
 	}
-	if err := CheckSchemas(baseline, candidate); err != nil {
+	baseline.Path = absOrOriginal(baselinePath)
+	candidate.Path = absOrOriginal(candidatePath)
+	if err := CheckSchemas(baseline.Report, candidate.Report); err != nil {
 		return Diff{}, err
 	}
-	return Build(baseline, candidate,
-		absOrOriginal(baselinePath), absOrOriginal(candidatePath),
-		now.UTC().Format(time.RFC3339))
+	return Build(baseline, candidate, now.UTC().Format(time.RFC3339))
 }
 
 // ExitCode maps the diff's overall result onto the process contract.
@@ -96,9 +83,43 @@ func ExitCode(d Diff) int {
 	}
 }
 
+// protectInputs refuses to write output over either input.
+//
+// The diff is held in memory by the time anything is written, so overwriting an
+// input cannot corrupt the comparison -- it destroys something worse. The
+// baseline is the user's record of what their last release supported: it is
+// often the only copy, it may have taken an hour of VM time to produce, and
+// `--out $BASELINE` in a CI script is one absent variable away. Refusing costs
+// a comparison of two strings.
+func protectInputs(d Diff, outPath, kind string) error {
+	abs, err := filepath.Abs(outPath)
+	if err != nil {
+		return fmt.Errorf("resolve diff %s path: %w", kind, err)
+	}
+	for _, in := range []struct{ side, path string }{
+		{"baseline", d.Baseline.Path},
+		{"candidate", d.Candidate.Path},
+	} {
+		if in.path == "" {
+			continue
+		}
+		inAbs, err := filepath.Abs(in.path)
+		if err != nil {
+			continue
+		}
+		if inAbs == abs {
+			return fmt.Errorf("refusing to write the diff %s over the %s report (%s): that is the evidence being compared", kind, in.side, abs)
+		}
+	}
+	return nil
+}
+
 func WriteJSON(outPath string, d Diff) error {
 	if strings.TrimSpace(outPath) == "" {
 		return nil
+	}
+	if err := protectInputs(d, outPath, "JSON"); err != nil {
+		return err
 	}
 	abs, err := filepath.Abs(outPath)
 	if err != nil {
@@ -119,6 +140,9 @@ func WriteJSON(outPath string, d Diff) error {
 func WriteMarkdown(outPath string, d Diff) error {
 	if strings.TrimSpace(outPath) == "" {
 		return nil
+	}
+	if err := protectInputs(d, outPath, "Markdown"); err != nil {
+		return err
 	}
 	abs, err := filepath.Abs(outPath)
 	if err != nil {

--- a/internal/regressiondiff/io.go
+++ b/internal/regressiondiff/io.go
@@ -90,12 +90,8 @@ func ExitCode(d Diff) int {
 // baseline is the user's record of what their last release supported: it is
 // often the only copy, it may have taken an hour of VM time to produce, and
 // `--out $BASELINE` in a CI script is one absent variable away. Refusing costs
-// a comparison of two strings.
+// two stat calls.
 func protectInputs(d Diff, outPath, kind string) error {
-	abs, err := filepath.Abs(outPath)
-	if err != nil {
-		return fmt.Errorf("resolve diff %s path: %w", kind, err)
-	}
 	for _, in := range []struct{ side, path string }{
 		{"baseline", d.Baseline.Path},
 		{"candidate", d.Candidate.Path},
@@ -103,15 +99,47 @@ func protectInputs(d Diff, outPath, kind string) error {
 		if in.path == "" {
 			continue
 		}
-		inAbs, err := filepath.Abs(in.path)
-		if err != nil {
-			continue
-		}
-		if inAbs == abs {
-			return fmt.Errorf("refusing to write the diff %s over the %s report (%s): that is the evidence being compared", kind, in.side, abs)
+		if SameFile(in.path, outPath) {
+			return fmt.Errorf("refusing to write the diff %s over the %s report (%s): that is the evidence being compared",
+				kind, in.side, in.path)
 		}
 	}
 	return nil
+}
+
+// SameFile reports whether two paths name the same file.
+//
+// Comparing absolute paths is not enough, and the difference is not academic: a
+// symbolic or hard link named anything at all resolves to the baseline report,
+// and `--out` through one destroyed the evidence while the guard saw two
+// unequal strings. Identity is what matters here, so identity is what is
+// compared -- os.SameFile answers it for anything that exists, links included.
+//
+// When a path does not exist yet (the normal case for an output file) there is
+// no inode to compare, so the paths are resolved as far as they can be: the
+// directory through EvalSymlinks, then the base name. That catches two routes
+// to one directory while still allowing an output file that has yet to be
+// created.
+func SameFile(a, b string) bool {
+	if ai, err := os.Stat(a); err == nil {
+		if bi, err := os.Stat(b); err == nil {
+			return os.SameFile(ai, bi)
+		}
+	}
+	return resolvedPath(a) == resolvedPath(b)
+}
+
+func resolvedPath(p string) string {
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		return p
+	}
+	dir, base := filepath.Split(abs)
+	resolvedDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return abs
+	}
+	return filepath.Join(resolvedDir, base)
 }
 
 func WriteJSON(outPath string, d Diff) error {

--- a/internal/regressiondiff/io.go
+++ b/internal/regressiondiff/io.go
@@ -1,8 +1,11 @@
 package regressiondiff
 
 import (
+	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"sort"
@@ -24,8 +27,9 @@ const (
 	ExitRegressed     = 2
 )
 
-// LoadReport reads one evidence file. A file that is absent or not valid JSON
-// is an error rather than an empty report, so a typo in a path can never be
+// LoadReport reads one evidence file. A file that is absent, not valid JSON, or
+// carrying anything after the report is an error rather than a partial report,
+// so neither a typo in a path nor a truncated or concatenated file can be
 // mistaken for "nothing regressed".
 func LoadReport(path string) (schema.ReportV01, error) {
 	blob, err := os.ReadFile(path)
@@ -33,11 +37,30 @@ func LoadReport(path string) (schema.ReportV01, error) {
 		return schema.ReportV01{}, fmt.Errorf("read report %s: %w", path, err)
 	}
 	var report schema.ReportV01
-	dec := json.NewDecoder(strings.NewReader(string(blob)))
+	dec := json.NewDecoder(bytes.NewReader(blob))
 	if err := dec.Decode(&report); err != nil {
 		return schema.ReportV01{}, fmt.Errorf("parse report %s: %w", path, err)
 	}
+	// Decode stops after one JSON value and is happy to leave the rest of the
+	// file unread. Evidence with anything after the report -- a second value, a
+	// truncated append, stray bytes -- is not evidence we can vouch for, and
+	// comparing only its first value would look entirely successful.
+	if err := requireEOF(dec); err != nil {
+		return schema.ReportV01{}, fmt.Errorf("parse report %s: %w", path, err)
+	}
 	return report, nil
+}
+
+func requireEOF(dec *json.Decoder) error {
+	var trailing json.RawMessage
+	switch err := dec.Decode(&trailing); {
+	case errors.Is(err, io.EOF):
+		return nil
+	case err != nil:
+		return fmt.Errorf("unexpected data after the report: %w", err)
+	default:
+		return fmt.Errorf("unexpected data after the report: a second JSON value is present")
+	}
 }
 
 // Compare loads both reports, validates their schemas and comparison keys, and

--- a/internal/regressiondiff/io.go
+++ b/internal/regressiondiff/io.go
@@ -1,0 +1,240 @@
+package regressiondiff
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+
+	"github.com/kernel-guard/bpfcompat/pkg/schema"
+)
+
+// Exit codes, matching the process contract the rest of bpfcompat uses:
+//
+//	0  no new required regression, and every required comparison was established
+//	1  the required comparison could not be established (never a claim about
+//	   the candidate's software)
+//	2  a required environment the baseline supported is broken in the candidate
+const (
+	ExitNoRegressions = 0
+	ExitInconclusive  = 1
+	ExitRegressed     = 2
+)
+
+// LoadReport reads one evidence file. A file that is absent or not valid JSON
+// is an error rather than an empty report, so a typo in a path can never be
+// mistaken for "nothing regressed".
+func LoadReport(path string) (schema.ReportV01, error) {
+	blob, err := os.ReadFile(path)
+	if err != nil {
+		return schema.ReportV01{}, fmt.Errorf("read report %s: %w", path, err)
+	}
+	var report schema.ReportV01
+	dec := json.NewDecoder(strings.NewReader(string(blob)))
+	if err := dec.Decode(&report); err != nil {
+		return schema.ReportV01{}, fmt.Errorf("parse report %s: %w", path, err)
+	}
+	return report, nil
+}
+
+// Compare loads both reports, validates their schemas and builds the diff. It
+// touches nothing but those two files: no database, no network, no service.
+func Compare(baselinePath, candidatePath string, now time.Time) (Diff, error) {
+	baseline, err := LoadReport(baselinePath)
+	if err != nil {
+		return Diff{}, err
+	}
+	candidate, err := LoadReport(candidatePath)
+	if err != nil {
+		return Diff{}, err
+	}
+	if err := CheckSchemas(baseline, candidate); err != nil {
+		return Diff{}, err
+	}
+	return Build(baseline, candidate,
+		absOrOriginal(baselinePath), absOrOriginal(candidatePath),
+		now.UTC().Format(time.RFC3339)), nil
+}
+
+// ExitCode maps the diff's overall result onto the process contract.
+func ExitCode(d Diff) int {
+	switch d.Summary.Result {
+	case ResultRegressed:
+		return ExitRegressed
+	case ResultInconclusive:
+		return ExitInconclusive
+	default:
+		return ExitNoRegressions
+	}
+}
+
+func WriteJSON(outPath string, d Diff) error {
+	if strings.TrimSpace(outPath) == "" {
+		return nil
+	}
+	abs, err := filepath.Abs(outPath)
+	if err != nil {
+		return fmt.Errorf("resolve diff JSON path: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		return fmt.Errorf("create diff JSON directory: %w", err)
+	}
+	blob, err := json.MarshalIndent(d, "", "  ")
+	if err != nil {
+		return fmt.Errorf("encode diff JSON: %w", err)
+	}
+	return os.WriteFile(abs, append(blob, '\n'), 0o600)
+}
+
+// WriteMarkdown renders the diff for humans. It is presentation only, derived
+// entirely from the JSON above -- never a second source of truth.
+func WriteMarkdown(outPath string, d Diff) error {
+	if strings.TrimSpace(outPath) == "" {
+		return nil
+	}
+	abs, err := filepath.Abs(outPath)
+	if err != nil {
+		return fmt.Errorf("resolve diff Markdown path: %w", err)
+	}
+	if err := os.MkdirAll(filepath.Dir(abs), 0o755); err != nil {
+		return fmt.Errorf("create diff Markdown directory: %w", err)
+	}
+	return os.WriteFile(abs, []byte(Markdown(d)), 0o600)
+}
+
+func Markdown(d Diff) string {
+	var b strings.Builder
+	b.WriteString("# bpfcompat Release Regression Diff\n\n")
+	b.WriteString(fmt.Sprintf("- Result: `%s`\n", d.Summary.Result))
+	b.WriteString(fmt.Sprintf("- Baseline: `%s` (run `%s`)\n", d.Baseline.Path, emptyAsDash(d.Baseline.RunID)))
+	b.WriteString(fmt.Sprintf("- Candidate: `%s` (run `%s`)\n", d.Candidate.Path, emptyAsDash(d.Candidate.RunID)))
+	if d.Baseline.ArtifactSHA256 != "" || d.Candidate.ArtifactSHA256 != "" {
+		b.WriteString(fmt.Sprintf("- Artifact: `%s` -> `%s`\n",
+			shortSHA(d.Baseline.ArtifactSHA256), shortSHA(d.Candidate.ArtifactSHA256)))
+	}
+	b.WriteString(fmt.Sprintf("- Loader contract: `%s` -> `%s`\n", d.Baseline.LoaderMode, d.Candidate.LoaderMode))
+
+	// Incomplete inputs are stated up front: a diff over partial evidence is a
+	// weaker claim than it looks, and this is what a reader sees first.
+	writeCoverage(&b, "Baseline", d.Summary.BaselineComplete)
+	writeCoverage(&b, "Candidate", d.Summary.CandidateComplete)
+
+	b.WriteString("\n## Summary\n\n")
+	b.WriteString("| Outcome | Count |\n|---|---:|\n")
+	for _, row := range []struct {
+		label string
+		n     int
+	}{
+		{"New required regressions", d.Summary.NewRequiredRegressions},
+		{"New optional regressions (non-gating)", d.Summary.NewOptionalRegressions},
+		{"Existing incompatibilities", d.Summary.ExistingIncompatibility},
+		{"Fixed", d.Summary.Fixed},
+		{"Unchanged compatible", d.Summary.UnchangedCompatible},
+		{"Inconclusive (required)", d.Summary.InconclusiveRequired},
+		{"Inconclusive (optional)", d.Summary.InconclusiveOptional},
+		{"Coverage added", d.Summary.CoverageAddedCount},
+		{"Coverage removed (required)", d.Summary.CoverageRemovedRequired},
+		{"Coverage removed (optional)", d.Summary.CoverageRemovedOptional},
+	} {
+		b.WriteString(fmt.Sprintf("| %s | %d |\n", row.label, row.n))
+	}
+
+	if len(d.Notes) > 0 {
+		b.WriteString("\n## Notes\n\n")
+		for _, n := range d.Notes {
+			b.WriteString("- " + n + "\n")
+		}
+	}
+
+	if len(d.Cells) > 0 {
+		b.WriteString("\n## Environments\n\n")
+		b.WriteString("| Profile | Required | Baseline | Candidate | Classification | Why |\n")
+		b.WriteString("|---|---|---|---|---|---|\n")
+		cells := append([]Cell(nil), d.Cells...)
+		sort.SliceStable(cells, func(i, j int) bool {
+			return classificationRank(cells[i]) < classificationRank(cells[j])
+		})
+		for i := range cells {
+			c := &cells[i]
+			b.WriteString(fmt.Sprintf("| `%s` | %s | %s | %s | `%s` | %s |\n",
+				c.ProfileID,
+				boolCell(c.Required),
+				emptyAsDash(c.Baseline.Verdict),
+				emptyAsDash(c.Candidate.Verdict),
+				c.Classification,
+				markdownCell(c.Reason),
+			))
+		}
+	}
+	return b.String()
+}
+
+func writeCoverage(b *strings.Builder, label string, complete *bool) {
+	if complete == nil {
+		return
+	}
+	if *complete {
+		b.WriteString("- " + label + " coverage: `complete`\n")
+		return
+	}
+	b.WriteString("- " + label + " coverage: `incomplete` — some environments produced no compatibility answer\n")
+}
+
+// classificationRank puts what blocks a release at the top of the table.
+func classificationRank(c Cell) int {
+	switch c.Classification {
+	case NewRegression:
+		if c.Required {
+			return 0
+		}
+		return 1
+	case CoverageRemoved, Inconclusive:
+		if c.Required {
+			return 2
+		}
+		return 4
+	case ExistingIncompatibility:
+		return 3
+	case Fixed:
+		return 5
+	case CoverageAdded:
+		return 6
+	default:
+		return 7
+	}
+}
+
+func boolCell(v bool) string {
+	if v {
+		return "yes"
+	}
+	return "no"
+}
+
+func emptyAsDash(v string) string {
+	if strings.TrimSpace(v) == "" {
+		return "-"
+	}
+	return v
+}
+
+func shortSHA(v string) string {
+	if len(v) > 12 {
+		return v[:12]
+	}
+	return emptyAsDash(v)
+}
+
+func markdownCell(v string) string {
+	return strings.ReplaceAll(strings.ReplaceAll(v, "|", "\\|"), "\n", " ")
+}
+
+func absOrOriginal(path string) string {
+	if abs, err := filepath.Abs(path); err == nil {
+		return abs
+	}
+	return path
+}

--- a/internal/regressiondiff/testdata/fuzz/FuzzLoadEvidence/956cf03b7e8d2a0a
+++ b/internal/regressiondiff/testdata/fuzz/FuzzLoadEvidence/956cf03b7e8d2a0a
@@ -1,0 +1,2 @@
+go test fuzz v1
+string("{\"schema_version\":\"v0.1\",\"run\":{\"id\":\"r1\"},\"targets\":[{\"profile_id\":\"k\",\"required\":true,\"status\":\"pass\",\"verdict\":\"COMPATIBLE\",\"environment\":{\"requested_kernel_family\":\"5.15\",\"observed_kernel\":\"5.15.0-1\",\"kernel_family_match\":ntll}}],\"summary\":{\"status\":\"pass\",\"verdict\":\"COMPATIBLE\",\"complete\":true}}")

--- a/internal/regressiondiff/trust_test.go
+++ b/internal/regressiondiff/trust_test.go
@@ -1,0 +1,859 @@
+package regressiondiff
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kernel-guard/bpfcompat/pkg/schema"
+)
+
+// The trust boundary. Every test in this file starts from evidence that a CI
+// input author could actually supply -- an older report, a hand-edited one, one
+// copied through an artifact store, one written by a different producer -- and
+// asserts the same thing: absence, ambiguity and contradiction never come out
+// as exit 0.
+
+// compareFiles runs the real load-validate-compare path over two files, which
+// is the only path a release gate uses.
+func compareFiles(t *testing.T, baseline, candidate string) (Diff, int, error) {
+	t.Helper()
+	dir := t.TempDir()
+	bp := filepath.Join(dir, "baseline.json")
+	cp := filepath.Join(dir, "candidate.json")
+	if err := os.WriteFile(bp, []byte(baseline), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cp, []byte(candidate), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	d, err := Compare(bp, cp, time.Unix(0, 0))
+	if err != nil {
+		// This is exactly what the CLI does with a refusal.
+		return Diff{}, ExitInconclusive, err
+	}
+	return d, ExitCode(d), nil
+}
+
+// jsonOf renders a report fixture. Tests that need JSON the Go type cannot
+// express (duplicate keys, absent fields, nulls) edit the text afterwards.
+func jsonOf(t *testing.T, r schema.ReportV01) string {
+	t.Helper()
+	blob, err := json.MarshalIndent(r, "", " ")
+	if err != nil {
+		t.Fatal(err)
+	}
+	return string(blob)
+}
+
+// green is a self-consistent pair that must compare cleanly, so that every
+// other test in this file is a single deliberate mutation away from a real
+// release decision.
+func greenPair(t *testing.T) (string, string) {
+	t.Helper()
+	return jsonOf(t, report(target("k", schema.VerdictCompatible, true))),
+		jsonOf(t, report(target("k", schema.VerdictCompatible, true)))
+}
+
+func TestGreenPairIsActuallyGreen(t *testing.T) {
+	base, cand := greenPair(t)
+	d, exit, err := compareFiles(t, base, cand)
+	if err != nil {
+		t.Fatalf("the control fixture must compare cleanly, got: %v", err)
+	}
+	if exit != ExitNoRegressions || d.Summary.Result != ResultNoRegressions {
+		t.Fatalf("control: want exit 0/%s, got exit %d/%s", ResultNoRegressions, exit, d.Summary.Result)
+	}
+}
+
+// STEP 2. A report does not become conclusive because one of its fields
+// contains the word COMPATIBLE.
+func TestContradictoryStatusAndVerdictIsRefused(t *testing.T) {
+	for _, tc := range []struct {
+		name, status, verdict string
+	}{
+		{"fail claiming compatible", "fail", schema.VerdictCompatible},
+		{"pass claiming incompatible", "pass", schema.VerdictIncompatible},
+		{"infra error claiming compatible", "infra_error", schema.VerdictCompatible},
+		{"pass claiming a verdict nothing defines", "pass", "SOMETHING_NEW"},
+		{"unsupported claiming compatible", "unsupported", schema.VerdictCompatible},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			bad := target("k", tc.verdict, true)
+			bad.Status = tc.status
+			// Built by hand: report() derives a self-consistent summary, and
+			// this fixture is deliberately not self-consistent.
+			r := report(bad)
+			r.Summary.Verdict = ""
+			r.Summary.Status = ""
+			r.Summary.Complete = nil
+
+			base, _ := greenPair(t)
+			for _, side := range []string{"baseline", "candidate"} {
+				var d Diff
+				var exit int
+				var err error
+				if side == "baseline" {
+					d, exit, err = compareFiles(t, jsonOf(t, r), base)
+				} else {
+					d, exit, err = compareFiles(t, base, jsonOf(t, r))
+				}
+				if err == nil {
+					t.Fatalf("%s: contradictory evidence produced a diff (%s)", side, d.Summary.Result)
+				}
+				var invalid *InvalidEvidenceError
+				if !errors.As(err, &invalid) {
+					t.Fatalf("%s: want InvalidEvidenceError, got %T: %v", side, err, err)
+				}
+				if exit != ExitInconclusive {
+					t.Fatalf("%s: contradictory evidence must be exit 1, not a verdict on the candidate; got %d", side, exit)
+				}
+				// The refusal must never be dressed up as a regression.
+				if strings.Contains(err.Error(), NewRegression) {
+					t.Fatalf("%s: a broken input file must not be reported as a regression: %v", side, err)
+				}
+			}
+		})
+	}
+}
+
+// An unknown verdict with nothing to contradict is unusable, not forged: it is
+// inconclusive rather than refused, and it still cannot be green.
+func TestUnknownVerdictWithoutStatusIsInconclusiveNotRefused(t *testing.T) {
+	odd := target("k", "SOMETHING_NEW", true)
+	odd.Status = ""
+	base, _ := greenPair(t)
+	d, exit, err := compareFiles(t, base, jsonOf(t, report(odd)))
+	if err != nil {
+		t.Fatalf("an unrecognised verdict is unusable evidence, not a contradiction: %v", err)
+	}
+	if got := onlyCell(t, d).Classification; got != Inconclusive {
+		t.Fatalf("want %s, got %s", Inconclusive, got)
+	}
+	if exit != ExitInconclusive {
+		t.Fatalf("want exit %d, got %d", ExitInconclusive, exit)
+	}
+}
+
+// STEP 7. Targets are the single source of semantic truth; a summary that
+// disagrees with them means the file disagrees with itself.
+func TestReportLevelContradictionsAreRefused(t *testing.T) {
+	C, I := schema.VerdictCompatible, schema.VerdictIncompatible
+
+	mutate := func(f func(*schema.ReportV01), targets ...schema.Target) string {
+		r := report(targets...)
+		f(&r)
+		return jsonOf(t, r)
+	}
+
+	for _, tc := range []struct {
+		name       string
+		report     string
+		wantSubstr string
+	}{
+		{
+			"summary claims INCOMPATIBLE while every required target passed",
+			mutate(func(r *schema.ReportV01) { r.Summary.Verdict = I; r.Summary.Status = "fail" }, target("k", C, true)),
+			"does not agree with itself",
+		},
+		{
+			"summary claims COMPATIBLE over a required incompatibility",
+			mutate(func(r *schema.ReportV01) { r.Summary.Verdict = C; r.Summary.Status = "pass" }, target("k", I, true)),
+			"does not agree with itself",
+		},
+		{
+			"summary claims complete while a target produced no answer",
+			mutate(func(r *schema.ReportV01) { r.Summary.Complete = b(true) },
+				target("k", C, true), target("opt", schema.VerdictInfraError, false)),
+			"summary.complete",
+		},
+		{
+			"summary claims complete while a required target ran the wrong kernel",
+			mutate(func(r *schema.ReportV01) { r.Summary.Complete = b(true) }, mismatched(target("k", C, true))),
+			"summary.complete",
+		},
+		{
+			"summary status and verdict contradict each other",
+			mutate(func(r *schema.ReportV01) { r.Summary.Status = "fail" }, target("k", C, true)),
+			"contradict",
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			base, _ := greenPair(t)
+			_, exit, err := compareFiles(t, base, tc.report)
+			if err == nil {
+				t.Fatal("a report that contradicts itself must not be carried forward as trustworthy evidence")
+			}
+			if !strings.Contains(err.Error(), tc.wantSubstr) {
+				t.Fatalf("want %q in %q", tc.wantSubstr, err.Error())
+			}
+			if exit != ExitInconclusive {
+				t.Fatalf("want exit %d, got %d", ExitInconclusive, exit)
+			}
+		})
+	}
+}
+
+// STEP 3 and 4. Missing evidence is never evidence of success. The Gate 1
+// helper answers "true" for an absent environment on purpose; Gate 2 asks a
+// stricter question and must not inherit that answer.
+func TestMissingEnvironmentEvidenceCannotBeGreen(t *testing.T) {
+	C := schema.VerdictCompatible
+
+	noEnvironment := func(tg schema.Target) schema.Target { tg.Environment = nil; return tg }
+	noMatch := func(tg schema.Target) schema.Target {
+		tg.Environment = &schema.EnvironmentCheck{
+			RequestedKernelFamily: "5.15", ObservedKernel: "5.15.0-186-generic",
+		}
+		return tg
+	}
+
+	for _, tc := range []struct {
+		name    string
+		degrade func(schema.Target) schema.Target
+	}{
+		{"no environment object at all", noEnvironment},
+		{"environment recorded but kernel_family_match absent", noMatch},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			for _, side := range []string{"baseline", "candidate", "both"} {
+				base := report(target("k", C, true))
+				cand := report(target("k", C, true))
+				if side != "candidate" {
+					base.Targets[0] = tc.degrade(base.Targets[0])
+					base.Summary.Complete = b(schema.RunComplete(base.Targets))
+				}
+				if side != "baseline" {
+					cand.Targets[0] = tc.degrade(cand.Targets[0])
+					cand.Summary.Complete = b(schema.RunComplete(cand.Targets))
+				}
+				d, exit, err := compareFiles(t, jsonOf(t, base), jsonOf(t, cand))
+				if err != nil {
+					t.Fatalf("%s: missing environment evidence is unusable, not malformed: %v", side, err)
+				}
+				cell := onlyCell(t, d)
+				if cell.Classification != Inconclusive {
+					t.Fatalf("%s: want %s, got %s (%s)", side, Inconclusive, cell.Classification, cell.Reason)
+				}
+				if exit != ExitInconclusive {
+					t.Fatalf("%s: a required obligation nothing established must not exit 0; got %d", side, exit)
+				}
+				// Unknown must not be reported as a mismatch: not recording a
+				// kernel and booting the wrong one are different findings.
+				if strings.Contains(cell.Reason, "but ran") {
+					t.Fatalf("%s: unknown environment was described as a mismatch: %s", side, cell.Reason)
+				}
+			}
+		})
+	}
+}
+
+// The stricter local rule is load-bearing: this is the mutation that would
+// reintroduce the fail-open, stated as an executable fact rather than a
+// comment. Swapping establishedEnvironment back to the Gate 1 helper makes the
+// diff green over evidence that never named a kernel.
+func TestGateTwoIsStricterThanTheGateOneHelper(t *testing.T) {
+	noEnv := &schema.Target{ProfileID: "k", Required: true, Status: "pass", Verdict: schema.VerdictCompatible}
+	if !schema.EstablishedRequestedEnvironment(noEnv) {
+		t.Fatal("precondition: the Gate 1 helper is lenient about absent environment metadata")
+	}
+	if got := establishedEnvironment(noEnv); got != EnvironmentUnknownEvidence {
+		t.Fatalf("Gate 2 must read absent environment metadata as %q, got %q", EnvironmentUnknownEvidence, got)
+	}
+	if conclusive(sideOf(noEnv)) {
+		t.Fatal("a side that never recorded its kernel must not be able to settle an obligation")
+	}
+	// ...while an explicit mismatch stays a mismatch, and a positive match
+	// stays established.
+	mism := *noEnv
+	mism.Environment = &schema.EnvironmentCheck{RequestedKernelFamily: "5.15", ObservedKernel: "6.1.0", KernelFamilyMatch: b(false)}
+	if got := establishedEnvironment(&mism); got != EnvironmentMismatchEvidence {
+		t.Fatalf("want %q, got %q", EnvironmentMismatchEvidence, got)
+	}
+	ok := *noEnv
+	ok.Environment = &schema.EnvironmentCheck{RequestedKernelFamily: "5.15", ObservedKernel: "5.15.0-186", KernelFamilyMatch: b(true)}
+	if got := establishedEnvironment(&ok); got != EnvironmentEstablishedEvidence {
+		t.Fatalf("want %q, got %q", EnvironmentEstablishedEvidence, got)
+	}
+}
+
+// A kernel_family_match with nothing it could have been derived from is an
+// assertion, not evidence.
+func TestUnattestedKernelFamilyMatchIsRefused(t *testing.T) {
+	for _, tc := range []struct {
+		name  string
+		strip func(*schema.EnvironmentCheck)
+	}{
+		{"requested kernel family removed", func(e *schema.EnvironmentCheck) { e.RequestedKernelFamily = "" }},
+		{"observed kernel removed", func(e *schema.EnvironmentCheck) { e.ObservedKernel = "" }},
+		{"both removed", func(e *schema.EnvironmentCheck) { e.RequestedKernelFamily = ""; e.ObservedKernel = "" }},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := report(target("k", schema.VerdictCompatible, true))
+			tc.strip(r.Targets[0].Environment)
+			base, _ := greenPair(t)
+			_, exit, err := compareFiles(t, base, jsonOf(t, r))
+			if err == nil {
+				t.Fatal("a kernel_family_match resting on nothing must not be accepted")
+			}
+			if exit != ExitInconclusive {
+				t.Fatalf("want exit %d, got %d", ExitInconclusive, exit)
+			}
+		})
+	}
+}
+
+// STEP 5. Duplicate object keys: encoding/json keeps the last value, so a file
+// a human reads as INCOMPATIBLE parses as COMPATIBLE.
+func TestDuplicateJSONKeysAreRefused(t *testing.T) {
+	base, _ := greenPair(t)
+	valid := jsonOf(t, report(target("k", schema.VerdictIncompatible, true)))
+
+	for _, tc := range []struct {
+		name, find, replace string
+	}{
+		{
+			"a second verdict overriding the first",
+			`"verdict": "INCOMPATIBLE"`,
+			`"verdict": "INCOMPATIBLE",` + "\n" + `  "verdict": "COMPATIBLE"`,
+		},
+		{
+			"a second schema_version smuggling an unknown schema past the check",
+			`"schema_version": "v0.1"`,
+			`"schema_version": "v9.0",` + "\n" + ` "schema_version": "v0.1"`,
+		},
+		{
+			"a second required demoting a gating obligation",
+			`"required": true`,
+			`"required": true,` + "\n" + `   "required": false`,
+		},
+		{
+			"a second profile_id",
+			`"profile_id": "k"`,
+			`"profile_id": "k",` + "\n" + `   "profile_id": "other"`,
+		},
+		{
+			"a second summary",
+			`"summary": {`,
+			`"summary": {"verdict": "COMPATIBLE"},` + "\n" + ` "summary": {`,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mutated := strings.Replace(valid, tc.find, tc.replace, 1)
+			if mutated == valid {
+				t.Fatalf("fixture did not mutate; looked for %q", tc.find)
+			}
+			// The mutation must really be accepted by a stock decoder,
+			// otherwise this test proves nothing about the risk.
+			var probe schema.ReportV01
+			if err := json.Unmarshal([]byte(mutated), &probe); err != nil {
+				t.Fatalf("precondition: encoding/json accepts duplicate keys, got %v", err)
+			}
+			_, exit, err := compareFiles(t, base, mutated)
+			if err == nil {
+				t.Fatal("a document whose fields have two values is ambiguous evidence")
+			}
+			if !strings.Contains(err.Error(), "appears twice") {
+				t.Fatalf("the refusal must name the ambiguity: %v", err)
+			}
+			if exit != ExitInconclusive {
+				t.Fatalf("want exit %d, got %d", ExitInconclusive, exit)
+			}
+		})
+	}
+}
+
+// STEP 6. A field whose absence and whose `false` deserialize to the same Go
+// value cannot be read from the struct alone.
+func TestAbsentRequirednessIsRefusedRatherThanReadAsOptional(t *testing.T) {
+	// The shape that matters: a proven regression on an obligation whose
+	// requiredness was deleted. Read as `false`, it is an optional finding and
+	// the release ships.
+	baseline := jsonOf(t, report(target("k", schema.VerdictCompatible, true)))
+	regressed := jsonOf(t, report(target("k", schema.VerdictIncompatible, true)))
+
+	for _, tc := range []struct {
+		name, replace string
+	}{
+		{"required omitted", ``},
+		{"required null", `"required": null,`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			cand := strings.Replace(regressed, `"required": true,`, tc.replace, 1)
+			base := strings.Replace(baseline, `"required": true,`, tc.replace, 1)
+			if cand == regressed {
+				t.Fatal("fixture did not mutate")
+			}
+			_, exit, err := compareFiles(t, base, cand)
+			if err == nil {
+				t.Fatal("a target that never states `required` leaves the support contract unknown")
+			}
+			if !strings.Contains(err.Error(), "required") {
+				t.Fatalf("the refusal must name the missing field: %v", err)
+			}
+			if exit != ExitInconclusive {
+				t.Fatalf("want exit %d, got %d", ExitInconclusive, exit)
+			}
+		})
+	}
+
+	// The control: `required: false` stated explicitly is a support decision,
+	// not missing evidence, and still compares. Built through report() so its
+	// run-level summary is derived from the optional target rather than
+	// inherited from the required fixture above.
+	optionalBase := jsonOf(t, report(target("k", schema.VerdictCompatible, false)))
+	optionalCand := jsonOf(t, report(target("k", schema.VerdictIncompatible, false)))
+	d, exit, err := compareFiles(t, optionalBase, optionalCand)
+	if err != nil {
+		t.Fatalf("an explicit `required: false` is evidence, not absence: %v", err)
+	}
+	if exit != ExitNoRegressions || d.Summary.NewOptionalRegressions != 1 {
+		t.Fatalf("an explicitly optional regression reports without gating: exit=%d summary=%+v", exit, d.Summary)
+	}
+}
+
+// Nulls and blanks must not become meaningful defaults.
+func TestNullAndBlankFieldsCannotBeGreen(t *testing.T) {
+	base, _ := greenPair(t)
+	valid := jsonOf(t, report(target("k", schema.VerdictCompatible, true)))
+
+	for _, tc := range []struct {
+		name, find, replace string
+		wantRefusal         bool
+	}{
+		{"environment null", `"environment": {`, `"environment": null, "unused": {`, false},
+		// A missing verdict is unusable rather than forged: `status` alone is
+		// the shape of every pre-Gate-1 report, so it is inconclusive, never a
+		// refusal -- and never green.
+		{"verdict null", `"verdict": "COMPATIBLE",`, `"verdict": null,`, false},
+		{"verdict empty", `"verdict": "COMPATIBLE",`, `"verdict": "",`, false},
+		{"verdict whitespace", `"verdict": "COMPATIBLE",`, `"verdict": "   ",`, false},
+		{"kernel_family_match null", `"kernel_family_match": true`, `"kernel_family_match": null`, false},
+		{"profile_id null", `"profile_id": "k"`, `"profile_id": null`, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mutated := strings.Replace(valid, tc.find, tc.replace, 1)
+			if mutated == valid {
+				t.Fatalf("fixture did not mutate; looked for %q", tc.find)
+			}
+			d, exit, err := compareFiles(t, base, mutated)
+			if exit == ExitNoRegressions {
+				t.Fatalf("a null or blank contract field must not produce a green comparison (err=%v result=%s)", err, d.Summary.Result)
+			}
+			if tc.wantRefusal && err == nil {
+				t.Fatalf("want a refusal, got %s", d.Summary.Result)
+			}
+		})
+	}
+}
+
+// STEP 8. The same profile_id can be pointed at a different promise.
+func TestSameProfileIDWithADifferentObligationIsInconclusive(t *testing.T) {
+	C := schema.VerdictCompatible
+	withProfile := func(arch, distro, version, family string) schema.Target {
+		tg := target("k", C, true)
+		tg.Profile = &schema.TargetEnv{Arch: arch, Distro: distro, Version: version, KernelFamily: family}
+		return tg
+	}
+	baselineTarget := withProfile("x86_64", "ubuntu", "22.04", "5.15")
+
+	for _, tc := range []struct {
+		name string
+		cand schema.Target
+		want string
+	}{
+		{"architecture changed", withProfile("arm64", "ubuntu", "22.04", "5.15"), "architecture"},
+		{"distro changed", withProfile("x86_64", "debian", "22.04", "5.15"), "distro"},
+		{"distro version changed", withProfile("x86_64", "ubuntu", "24.04", "5.15"), "distro version"},
+		{"kernel family changed", withProfile("x86_64", "ubuntu", "22.04", "6.1"), "kernel family"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d, exit, err := compareFiles(t,
+				jsonOf(t, report(baselineTarget)), jsonOf(t, report(tc.cand)))
+			if err != nil {
+				t.Fatalf("a changed obligation is not malformed evidence: %v", err)
+			}
+			cell := onlyCell(t, d)
+			if cell.Classification != Inconclusive {
+				t.Fatalf("want %s, got %s (%s)", Inconclusive, cell.Classification, cell.Reason)
+			}
+			if !strings.Contains(cell.Reason, tc.want) {
+				t.Fatalf("the reason must name what changed: want %q in %q", tc.want, cell.Reason)
+			}
+			if exit != ExitInconclusive {
+				t.Fatalf("want exit %d, got %d", ExitInconclusive, exit)
+			}
+		})
+	}
+
+	// The control: an identical obligation still compares, and a profile block
+	// present on only one side is absence rather than change.
+	d := build(t, report(baselineTarget), report(baselineTarget))
+	if got := onlyCell(t, d).Classification; got != UnchangedCompatible {
+		t.Fatalf("an unchanged obligation must still compare: got %s", got)
+	}
+	half := target("k", C, true)
+	d = build(t, report(baselineTarget), report(half))
+	if got := onlyCell(t, d).Classification; got != UnchangedCompatible {
+		t.Fatalf("an absent profile block is unknown, not a changed obligation: got %s", got)
+	}
+}
+
+// A shallower candidate must not inherit a deeper baseline's green.
+func TestValidationDepthChangeIsInconclusive(t *testing.T) {
+	C := schema.VerdictCompatible
+	withAttach := func(mode string) schema.Target {
+		tg := target("k", C, true)
+		tg.Validation = &schema.Validation{AttachMode: mode}
+		return tg
+	}
+	d, exit, err := compareFiles(t,
+		jsonOf(t, report(withAttach("best-effort"))), jsonOf(t, report(withAttach("disabled"))))
+	if err != nil {
+		t.Fatalf("unexpected refusal: %v", err)
+	}
+	cell := onlyCell(t, d)
+	if cell.Classification != Inconclusive {
+		t.Fatalf("want %s, got %s (%s)", Inconclusive, cell.Classification, cell.Reason)
+	}
+	if exit != ExitInconclusive {
+		t.Fatalf("want exit %d, got %d", ExitInconclusive, exit)
+	}
+	if got := onlyCell(t, build(t, report(withAttach("best-effort")), report(withAttach("best-effort")))).Classification; got != UnchangedCompatible {
+		t.Fatalf("an unchanged attach mode must still compare: got %s", got)
+	}
+}
+
+// STEP 9. Loader identity: what is the product, and what is the instrument.
+func TestLoaderIdentitySemantics(t *testing.T) {
+	C := schema.VerdictCompatible
+
+	t.Run("a changed command contract makes every cell inconclusive", func(t *testing.T) {
+		for _, tc := range []struct {
+			name string
+			edit func(*schema.CommandInfo)
+		}{
+			{"different command", func(c *schema.CommandInfo) { c.InvocationSHA256 = "other" }},
+			{"different success exit code", func(c *schema.CommandInfo) { c.ExpectedExitCode = 7 }},
+		} {
+			t.Run(tc.name, func(t *testing.T) {
+				base := report(target("k", C, true))
+				base.Command = &schema.CommandInfo{InvocationSHA256: "inv", ExpectedExitCode: 0,
+					Binary: &schema.BinaryIdentity{SHA256: "loader-v1"}}
+				cand := report(target("k", C, true))
+				cmd := *base.Command
+				cmd.Binary = &schema.BinaryIdentity{SHA256: "loader-v2"}
+				tc.edit(&cmd)
+				cand.Command = &cmd
+
+				d, exit, err := compareFiles(t, jsonOf(t, base), jsonOf(t, cand))
+				if err != nil {
+					t.Fatalf("unexpected refusal: %v", err)
+				}
+				if got := onlyCell(t, d).Classification; got != Inconclusive {
+					t.Fatalf("want %s, got %s", Inconclusive, got)
+				}
+				if exit != ExitInconclusive {
+					t.Fatalf("want exit %d, got %d", ExitInconclusive, exit)
+				}
+				if len(d.Notes) == 0 {
+					t.Fatal("the contract change must be stated in the evidence")
+				}
+			})
+		}
+	})
+
+	// The project's own loader is the thing being released. Requiring it to be
+	// byte-identical between release N and N+1 would make every real command
+	// mode comparison incomparable, which is not a safety property -- it is a
+	// gate nobody can use.
+	t.Run("the project's loader binary may change", func(t *testing.T) {
+		base := report(target("k", C, true))
+		base.Command = &schema.CommandInfo{InvocationSHA256: "inv", Binary: &schema.BinaryIdentity{SHA256: "loader-v1"}}
+		cand := report(target("k", C, true))
+		cand.Command = &schema.CommandInfo{InvocationSHA256: "inv", Binary: &schema.BinaryIdentity{SHA256: "loader-v2"}}
+
+		d, exit, err := compareFiles(t, jsonOf(t, base), jsonOf(t, cand))
+		if err != nil {
+			t.Fatalf("unexpected refusal: %v", err)
+		}
+		if got := onlyCell(t, d).Classification; got != UnchangedCompatible {
+			t.Fatalf("a new build of the released loader is the point of the comparison; got %s", got)
+		}
+		if exit != ExitNoRegressions {
+			t.Fatalf("want exit 0, got %d", exit)
+		}
+	})
+
+	// The generic validator is bpfcompat's measuring instrument. A changed
+	// build is recorded as traceability, and deliberately does not gate.
+	t.Run("a changed validator build is noted, not gated", func(t *testing.T) {
+		base := report(target("k", C, true))
+		base.Validator = &schema.BinaryIdentity{SHA256: strings.Repeat("a", 64)}
+		cand := report(target("k", C, true))
+		cand.Validator = &schema.BinaryIdentity{SHA256: strings.Repeat("b", 64)}
+
+		d, exit, err := compareFiles(t, jsonOf(t, base), jsonOf(t, cand))
+		if err != nil {
+			t.Fatalf("unexpected refusal: %v", err)
+		}
+		if exit != ExitNoRegressions {
+			t.Fatalf("a bpfcompat upgrade must not make every environment incomparable; got exit %d", exit)
+		}
+		if len(d.Notes) == 0 || !strings.Contains(strings.Join(d.Notes, " "), "validator build differs") {
+			t.Fatalf("the instrument change must be traceable in the evidence: %v", d.Notes)
+		}
+	})
+}
+
+// STEP 10. A hostile CI artifact must not be read into memory before it is
+// judged.
+func TestOversizedEvidenceIsRefusedBeforeParsing(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "huge.json")
+	f, err := os.Create(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString(`{"schema_version":"v0.1","filler":"`); err != nil {
+		t.Fatal(err)
+	}
+	chunk := strings.Repeat("A", 1<<20)
+	for written := 0; written <= maxEvidenceBytes; written += len(chunk) {
+		if _, err := f.WriteString(chunk); err != nil {
+			t.Fatal(err)
+		}
+	}
+	if err := f.Close(); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadEvidence(path, "candidate"); err == nil {
+		t.Fatal("a file past the evidence limit must be refused")
+	} else if !strings.Contains(err.Error(), "evidence limit") {
+		t.Fatalf("the refusal must say why: %v", err)
+	}
+}
+
+// Deep nesting must be refused rather than recursed into.
+func TestPathologicallyNestedJSONIsRefusedNotRecursed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "deep.json")
+	deep := strings.Repeat("[", 20000) + strings.Repeat("]", 20000)
+	if err := os.WriteFile(path, []byte(deep), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadEvidence(path, "candidate"); err == nil {
+		t.Fatal("deeply nested input must be refused")
+	}
+}
+
+// STEP 11. The comparison must not destroy the evidence it compares.
+func TestOutputNeverOverwritesInputEvidence(t *testing.T) {
+	dir := t.TempDir()
+	bp := filepath.Join(dir, "baseline.json")
+	cp := filepath.Join(dir, "candidate.json")
+	base, cand := greenPair(t)
+	if err := os.WriteFile(bp, []byte(base), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(cp, []byte(cand), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	d, err := Compare(bp, cp, time.Unix(0, 0))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for _, tc := range []struct {
+		name, path string
+	}{
+		{"over the baseline", bp},
+		{"over the candidate", cp},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			before, err := os.ReadFile(tc.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if err := WriteJSON(tc.path, d); err == nil {
+				t.Fatal("writing the diff over its own input must be refused")
+			}
+			if err := WriteMarkdown(tc.path, d); err == nil {
+				t.Fatal("writing the Markdown over its own input must be refused")
+			}
+			after, err := os.ReadFile(tc.path)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if !bytes.Equal(before, after) {
+				t.Fatal("the input evidence was modified")
+			}
+		})
+	}
+
+	// A path that is not an input still writes.
+	out := filepath.Join(dir, "diff.json")
+	if err := WriteJSON(out, d); err != nil {
+		t.Fatalf("a normal output path must still work: %v", err)
+	}
+	if _, err := os.Stat(out); err != nil {
+		t.Fatalf("diff JSON was not written: %v", err)
+	}
+}
+
+// STEP 12. Comparing a run with itself is a wiring mistake, not a release
+// decision: it is permanently, trivially green.
+func TestAReportComparedWithItselfIsRefused(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "report.json")
+	base, _ := greenPair(t)
+	if err := os.WriteFile(path, []byte(base), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := Compare(path, path, time.Unix(0, 0)); err == nil {
+		t.Fatal("the same file on both sides must not produce a green release gate")
+	}
+
+	// The same run copied to two paths is the same wiring mistake wearing a
+	// different name, and is caught by run identity rather than by path.
+	copyPath := filepath.Join(dir, "copy.json")
+	if err := os.WriteFile(copyPath, []byte(base), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Compare(path, copyPath, time.Unix(0, 0))
+	if err == nil {
+		t.Fatal("a copy of the same run must be recognised as the same run")
+	}
+	if !strings.Contains(err.Error(), "same run") {
+		t.Fatalf("the refusal must name the cause: %v", err)
+	}
+
+	// Two genuinely distinct runs with the same content still compare: it is
+	// run identity that matters, not byte equality.
+	other := report(target("k", schema.VerdictCompatible, true))
+	otherPath := filepath.Join(dir, "other.json")
+	if err := os.WriteFile(otherPath, []byte(jsonOf(t, other)), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := Compare(path, otherPath, time.Unix(0, 0)); err != nil {
+		t.Fatalf("two distinct runs must compare: %v", err)
+	}
+}
+
+// STEP 14, expressed as behaviour: every guard added here is load-bearing, so
+// removing any one of them turns one of these inputs green. Each row is a
+// fail-open mutation stated as an input rather than as a patch to the source.
+func TestNoUntrustworthyEvidenceReachesExitZero(t *testing.T) {
+	C, I := schema.VerdictCompatible, schema.VerdictIncompatible
+	base, _ := greenPair(t)
+
+	contradictory := report(target("k", C, true))
+	contradictory.Targets[0].Status = "fail"
+	contradictory.Summary = schema.SummaryInfo{}
+
+	noEnv := report(target("k", C, true))
+	noEnv.Targets[0].Environment = nil
+	noEnv.Summary.Complete = b(schema.RunComplete(noEnv.Targets))
+
+	summaryLies := report(target("k", C, true))
+	summaryLies.Summary.Verdict = I
+	summaryLies.Summary.Status = "fail"
+
+	archChanged := report(target("k", C, true))
+	archChanged.Targets[0].Profile = &schema.TargetEnv{Arch: "arm64"}
+
+	regressed := jsonOf(t, report(target("k", I, true)))
+
+	for _, tc := range []struct{ name, candidate string }{
+		{"status and verdict contradict", jsonOf(t, contradictory)},
+		{"environment never recorded", jsonOf(t, noEnv)},
+		{"summary contradicts its targets", jsonOf(t, summaryLies)},
+		{"duplicate verdict keys", strings.Replace(jsonOf(t, report(target("k", I, true))),
+			`"verdict": "INCOMPATIBLE"`, `"verdict": "INCOMPATIBLE",`+"\n"+`  "verdict": "COMPATIBLE"`, 1)},
+		{"requiredness deleted around a regression", strings.Replace(regressed, `"required": true,`, ``, 1)},
+		{"trailing second document", jsonOf(t, report(target("k", C, true))) + "\n{}"},
+		{"obligation silently repointed at another architecture", jsonOf(t, archChanged)},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			baselineJSON := base
+			if strings.Contains(tc.name, "architecture") {
+				withProfile := report(target("k", C, true))
+				withProfile.Targets[0].Profile = &schema.TargetEnv{Arch: "x86_64"}
+				baselineJSON = jsonOf(t, withProfile)
+			}
+			d, exit, err := compareFiles(t, baselineJSON, tc.candidate)
+			if exit == ExitNoRegressions {
+				t.Fatalf("untrustworthy evidence reached exit 0 (result=%s err=%v)", d.Summary.Result, err)
+			}
+		})
+	}
+}
+
+// The mirror: none of the new strictness may turn a genuine, complete,
+// self-consistent pair into a refusal. A gate that fails on real evidence is
+// not a safer gate, it is an ignored one.
+func TestGenuineEvidenceStillCompares(t *testing.T) {
+	C, I := schema.VerdictCompatible, schema.VerdictIncompatible
+	full := func(verdict string, required bool) schema.Target {
+		tg := target("k", verdict, required)
+		tg.Profile = &schema.TargetEnv{Distro: "ubuntu", Version: "22.04", KernelFamily: "5.15", Arch: "x86_64"}
+		tg.Validation = &schema.Validation{AttachMode: "best-effort", LoadStatus: "ok"}
+		return tg
+	}
+	for _, tc := range []struct {
+		name       string
+		base, cand string
+		wantClass  string
+		wantExit   int
+	}{
+		{"still supported", C, C, UnchangedCompatible, ExitNoRegressions},
+		{"newly broken", C, I, NewRegression, ExitRegressed},
+		{"still broken", I, I, ExistingIncompatibility, ExitNoRegressions},
+		{"newly fixed", I, C, Fixed, ExitNoRegressions},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d, exit, err := compareFiles(t,
+				jsonOf(t, report(full(tc.base, true))), jsonOf(t, report(full(tc.cand, true))))
+			if err != nil {
+				t.Fatalf("genuine evidence was refused: %v", err)
+			}
+			if got := onlyCell(t, d).Classification; got != tc.wantClass {
+				t.Fatalf("want %s, got %s (%s)", tc.wantClass, got, onlyCell(t, d).Reason)
+			}
+			if exit != tc.wantExit {
+				t.Fatalf("want exit %d, got %d", tc.wantExit, exit)
+			}
+		})
+	}
+}
+
+// Pre-Gate-1 reports are the most common real-world "older report": they carry
+// status and no verdict, and no environment at all. They must be readable and
+// unusable -- refusing them outright would confuse age with tampering, and
+// trusting them would let evidence that predates the contract gate a release.
+func TestPreGateOneReportsAreReadableButNeverConclusive(t *testing.T) {
+	old := schema.ReportV01{
+		SchemaVersion: "v0.1",
+		Run:           schema.RunInfo{ID: fmt.Sprintf("legacy-%d", runIDs.Add(1))},
+		Targets:       []schema.Target{{ProfileID: "k", Required: true, Status: "pass"}},
+		Summary:       schema.SummaryInfo{Status: "pass"},
+	}
+	base, _ := greenPair(t)
+	d, exit, err := compareFiles(t, jsonOf(t, old), base)
+	if err != nil {
+		t.Fatalf("an older report is unusable evidence, not malformed evidence: %v", err)
+	}
+	if got := onlyCell(t, d).Classification; got != Inconclusive {
+		t.Fatalf("want %s, got %s", Inconclusive, got)
+	}
+	if exit != ExitInconclusive {
+		t.Fatalf("want exit %d, got %d", ExitInconclusive, exit)
+	}
+}

--- a/internal/regressiondiff/trust_test.go
+++ b/internal/regressiondiff/trust_test.go
@@ -697,6 +697,71 @@ func TestOutputNeverOverwritesInputEvidence(t *testing.T) {
 		})
 	}
 
+	// A link is a different name for the same file, and the guard compares
+	// identity rather than spelling. Comparing absolute paths let `--out
+	// alias.json` destroy the baseline it pointed at while the check saw two
+	// unequal strings.
+	t.Run("through a symbolic link", func(t *testing.T) {
+		alias := filepath.Join(dir, "alias.json")
+		if err := os.Symlink(bp, alias); err != nil {
+			t.Skipf("symlinks unavailable: %v", err)
+		}
+		defer os.Remove(alias) //nolint:errcheck // best effort cleanup
+		before, err := os.ReadFile(bp)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := WriteJSON(alias, d); err == nil {
+			t.Fatal("a symlink to the baseline is still the baseline")
+		}
+		after, err := os.ReadFile(bp)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(before, after) {
+			t.Fatal("the baseline evidence was destroyed through a symlink")
+		}
+	})
+
+	t.Run("through a hard link", func(t *testing.T) {
+		hard := filepath.Join(dir, "hard.json")
+		if err := os.Link(bp, hard); err != nil {
+			t.Skipf("hard links unavailable: %v", err)
+		}
+		defer os.Remove(hard) //nolint:errcheck // best effort cleanup
+		before, err := os.ReadFile(bp)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if err := WriteMarkdown(hard, d); err == nil {
+			t.Fatal("a hard link to the baseline is still the baseline")
+		}
+		after, err := os.ReadFile(bp)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if !bytes.Equal(before, after) {
+			t.Fatal("the baseline evidence was destroyed through a hard link")
+		}
+	})
+
+	// Two names for one output file must be recognised as one file; two
+	// genuinely different ones must not.
+	t.Run("output identity", func(t *testing.T) {
+		if !SameFile(bp, bp) {
+			t.Fatal("a path must be the same file as itself")
+		}
+		if SameFile(bp, cp) {
+			t.Fatal("two distinct reports must not compare as one file")
+		}
+		if !SameFile(filepath.Join(dir, "new.json"), filepath.Join(dir, "sub", "..", "new.json")) {
+			t.Fatal("two routes to one not-yet-created file must compare as one file")
+		}
+		if SameFile(filepath.Join(dir, "a.json"), filepath.Join(dir, "b.json")) {
+			t.Fatal("two not-yet-created files with different names are not one file")
+		}
+	})
+
 	// A path that is not an input still writes.
 	out := filepath.Join(dir, "diff.json")
 	if err := WriteJSON(out, d); err != nil {


### PR DESCRIPTION
## Problem

An absolute compatibility matrix cannot answer the question a release manager actually asks. A release that has *always* failed on 4.14 and one that *broke* 4.14 yesterday are both red.

Inspektor Gadget's maintainers had already built the missing layer themselves, in Python, on top of our reports — `classify_change()` with `regression` / `improvement` / `existing_limitation` / `passing` / `incomplete`, with an incomplete-first short-circuit. They wrote it because the tool did not provide it.

## Solution

`bpfcompat diff --baseline a.json --candidate b.json` — **stateless and offline**. Two files in, one diff out. No database, no history store, no network, no service.

**Comparison unit** is a support obligation, keyed on `profile_id`. Deliberately *not* keyed on the artifact SHA-256 (release N and N+1 are supposed to differ) nor the observed kernel (Gate 1 separates requested from observed). Two guards keep the key honest — a profile that changed which kernel family it requests is a different promise wearing the same name, and a baseline taken with the generic validator against a candidate driven by its own loader is not like-for-like. Both are inconclusive rather than wrong.

**Classifications:** `UNCHANGED_COMPATIBLE`, `NEW_REGRESSION`, `EXISTING_INCOMPATIBILITY`, `FIXED`, `INCONCLUSIVE`, `COVERAGE_ADDED`, `COVERAGE_REMOVED`. Only `NEW_REGRESSION` is a statement about the candidate's software.

**The rule it all rests on:** an unproven baseline can never manufacture a regression. Baseline `INFRA_ERROR` + candidate `INCOMPATIBLE` = `INCONCLUSIVE`, not `NEW_REGRESSION` — the baseline never proved the environment worked. The candidate's incompatibility stays visible as evidence. The mirror rule holds too: a proven required regression outranks inconclusive noise, so a flaky optional VM cannot bury it.

**required/optional** follows Gate 1 exactly — only required cells gate. A `required` → `optional` demotion is recorded as `required_changed` so downgrading a profile to dodge a gate is visible.

**Exits** `0` / `1` / `2` mirror the existing process contract; `2` outranks `1`.

## Why a new subcommand, not a change to `compare`

`compare` predates the verdict contract, ranks statuses ordinally (`pass 3 > fail 2 > infra_error 1`), and is consumed by the **frozen** experimental API. Under it, a VM that failed to boot reads as a *regression*, and a genuine incompatibility appearing where there was an infra error reads as an *improvement*. It is left untouched.

The divergence is real and checkable. On `rhel-8-4.18` evidence — which passed on a `5.15.0-…el8uek` kernel its profile calls 4.18:

```
compare:  profiles=1 changed=0 improved=0 regressed=0   (exit 0)
diff:     result=INCONCLUSIVE  cell=INCONCLUSIVE        (exit 1)
```

## Evidence

Real reports, generated by this product against real VMs. Baseline `perfbuf-fallback` (portable), candidate `ringbuf-modern` (needs ≥5.8) across `ubuntu-22.04-5.15` + `ubuntu-20.04-5.4`:

| Direction | Result | Cells |
|---|---|---|
| release N → N+1 | exit **2** | `5.4=NEW_REGRESSION` (`UNSUPPORTED_MAP_TYPE`), `5.15=UNCHANGED_COMPATIBLE` |
| release N+1 → N | exit **0** | `5.4=FIXED`, `5.15=UNCHANGED_COMPATIBLE` |
| same release twice | exit **0** | `5.4=EXISTING_INCOMPATIBILITY`, `5.15=UNCHANGED_COMPATIBLE` |

Plus, on other real reports: clean → exit 0; required infra gap → exit 1 `INCONCLUSIVE`; environment mismatch → exit 1 `INCONCLUSIVE`.

**Agreement with IG's script** on the same real reports:

| profile | IG `classify_change` | `bpfcompat diff` |
|---|---|---|
| `ubuntu-20.04-5.4` | `regression` | `NEW_REGRESSION` |
| `ubuntu-22.04-5.15` | `passing` | `UNCHANGED_COMPATIBLE` |

14-row comparison table test, plus order-independence, loader-contract change, changed-obligation, schema fail-closed, malformed/missing evidence, and the two boundary properties. Six seeded mutations (drop the inconclusive short-circuit, ignore environment mismatch, stop reporting required regressions, stop gating on required inconclusive, treat optional as required, remove deterministic ordering) are each caught.

Full gate green including `golangci-lint run --timeout=5m --new-from-rev=origin/main`, `-race`, release-consistency, docs-drift, doc-pins, canary-pins, asset-verify, experimental-freeze, actionlint, coverage 52.2%.

## Backwards compatibility

Purely additive. Zero changes to `pkg/schema/`, `internal/runner/`, `internal/report/`, `action.yml` or `.github/` — Gate 1's contract and every existing consumer path are untouched. `internal/compare/` is untouched and the `compare` command still behaves identically. Nothing requires adopting `diff`.

## Scope

Two evidence files → deterministic release regression diff. No persistence, no API, no dashboard, no prediction. Storing evidence over time is explicitly out of scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012pAFqm7feYyEMFogqo9jaY


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added the `bpfcompat diff` command to compare baseline and candidate compatibility reports.
  - Reports regressions, existing incompatibilities, fixes, inconclusive results, and coverage changes.
  - Supports JSON and Markdown output with CI-friendly exit codes.
  - Validates evidence and rejects incomplete, ambiguous, malformed, contradictory, or mismatched inputs.
  - Prevents outputs from overwriting source reports.

- **Documentation**
  - Added a release regression diff guide covering usage, classifications, outputs, and CI integration.
  - Linked the guide from the Quickstart documentation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->