### PR TITLE
fix(diff): close remaining evidence trust-boundary gaps

### DIFF
--- a/docs/release-regression-diff.md
+++ b/docs/release-regression-diff.md
@@ -48,13 +48,31 @@ Guards protect the key from matching things that only look alike. A
 - if the two sides exercised **different amounts of the contract** (different
   `validation.attach_mode`), the cell is inconclusive. A load-only candidate
   cannot inherit an attach-tested baseline's green;
+
+**One-sided absence is inconclusive too.** For every dimension above, and for
+the command-mode identity below, three cases are distinguished:
+
+| Baseline | Candidate | Result |
+|---|---|---|
+| present | present, equal | comparable |
+| present | present, different | `INCONCLUSIVE` — the obligation changed |
+| present | **absent** (or the reverse) | `INCONCLUSIVE` — equivalence cannot be established |
+| absent | absent | comparable; this is the shape of older evidence, and age is not tampering |
+
+The one-sided row exists because the alternative rewards deletion: treating a
+missing field as "nothing to compare" made removing the candidate's profile
+metadata a way to turn a changed architecture back into an unchanged one.
+Weakening the evidence must never buy a greener answer.
 - if one report was produced by the generic validator and the other by a
   project's own loader (command mode), the loader contract changed and every
   cell is inconclusive. "Did it regress" has no meaning when the thing doing the
   loading also changed;
 - in command mode, if the **command under test** (`invocation_sha256`) or the
-  **exit code that counts as success** changed, every cell is inconclusive: the
-  two runs answer different questions.
+  **exit code that counts as success** changed — or either is recorded on only
+  one side — every cell is inconclusive: it is not established that the two runs
+  executed the same test. `expected_exit_code` is a plain integer, so its
+  presence is read from the raw JSON; a deleted field would otherwise decode as
+  `0` and silently match any baseline expecting success.
 
 ### What is allowed to change
 
@@ -146,6 +164,17 @@ comparison keys cannot be trusted. Each produces exit `1` with an explanation:
   `"verdict":"INCOMPATIBLE","verdict":"COMPATIBLE"` parses green while a human
   reading the file sees a failure. Which value a release decision came from must
   not depend on a parser's choice;
+- **two keys in one object that differ only by case**, such as `"verdict"` and
+  `"Verdict"`. Struct field matching falls back to a case-insensitive match, so
+  both bind to the same field and the later one wins — the same ambiguity in a
+  different spelling. Keys that differ by more than case (`profileid`,
+  `ProfileID`) bind to nothing and are unaffected, as are ordinary extension
+  fields;
+- a **`kernel_family_match` that disagrees with its own inputs**. The field is
+  arithmetic, not testimony: it is recomputed from the requested family and the
+  observed kernel with the same primitive the runner used to record it. A report
+  claiming `requested 4.18, observed 5.15.0-206.el8uek, match true` is refused,
+  as is one claiming a match whose inputs carry no readable kernel series;
 - a target that **does not state `required`** (absent, or `null`). It
   deserializes to `false`, which would silently demote a proven regression to a
   non-gating optional finding. Deleting the field is not a way to discover that

--- a/internal/regressiondiff/diff.go
+++ b/internal/regressiondiff/diff.go
@@ -222,15 +222,34 @@ func validateTarget(t *schema.Target, i int, id, side string) error {
 			"target %d (%s) records status %q and verdict %q, which contradict each other (status %q means %q); this report does not agree with itself",
 			i, id, status, verdict, status, schema.VerdictForStatus(status))}
 	}
-	// kernel_family_match is a claim derived from two other fields: the runner
-	// sets it only after parsing a kernel series out of both the requested
-	// family and the observed kernel. A `true` standing alone, with nothing it
-	// could have been derived from, is an assertion rather than evidence.
+	// kernel_family_match is not testimony, it is arithmetic: the runner derives
+	// it from the requested family and the observed kernel with
+	// schema.KernelFamilyMatch, and this recomputes it with the same primitive.
+	//
+	// Checking only that the inputs exist proves the boolean had something to be
+	// derived from, not that it was. A report claiming `requested 4.18, observed
+	// 5.15.0-206.el8uek, match true` passed that check and let the differ treat a
+	// kernel series nothing tested as established -- the exact environment
+	// identity failure Gate 1 exists to prevent, reintroduced through a field
+	// nobody verified.
 	if env := t.Environment; env != nil && env.KernelFamilyMatch != nil {
 		if strings.TrimSpace(env.RequestedKernelFamily) == "" || strings.TrimSpace(env.ObservedKernel) == "" {
 			return &InvalidEvidenceError{Side: side, Reason: fmt.Sprintf(
 				"target %d (%s) states kernel_family_match without recording both the requested kernel family and the observed kernel, so the claim rests on nothing",
 				i, id)}
+		}
+		match, derivable := schema.KernelFamilyMatch(env.RequestedKernelFamily, env.ObservedKernel)
+		if !derivable {
+			// A boolean whose own inputs cannot produce one. The producer would
+			// have left it unset; something else wrote this.
+			return &InvalidEvidenceError{Side: side, Reason: fmt.Sprintf(
+				"target %d (%s) states kernel_family_match, but no kernel series can be read from requested family %q and observed kernel %q, so that answer cannot have been derived",
+				i, id, env.RequestedKernelFamily, env.ObservedKernel)}
+		}
+		if match != *env.KernelFamilyMatch {
+			return &InvalidEvidenceError{Side: side, Reason: fmt.Sprintf(
+				"target %d (%s) records kernel_family_match %t, but requested family %q against observed kernel %q is %t; this report does not agree with itself",
+				i, id, *env.KernelFamilyMatch, env.RequestedKernelFamily, env.ObservedKernel, match)}
 		}
 	}
 	return nil
@@ -338,16 +357,36 @@ func checkDistinctRuns(baseline, candidate Evidence) error {
 // the command that was run (recorded as invocation_sha256, the text itself
 // never being published) and the exit code that counts as success. Change
 // either and a later COMPATIBLE is an answer to a different question.
-func commandContractChanged(baseline, candidate schema.ReportV01) (string, bool) {
-	b, c := baseline.Command, candidate.Command
+func commandContractChanged(baseline, candidate Evidence) (string, bool) {
+	b, c := baseline.Report.Command, candidate.Report.Command
 	if b == nil || c == nil {
 		return "", false
 	}
-	if strings.TrimSpace(b.InvocationSHA256) != "" && strings.TrimSpace(c.InvocationSHA256) != "" &&
-		strings.TrimSpace(b.InvocationSHA256) != strings.TrimSpace(c.InvocationSHA256) {
+	bInv, cInv := strings.TrimSpace(b.InvocationSHA256), strings.TrimSpace(c.InvocationSHA256)
+	switch {
+	case bInv == "" && cInv == "":
+		// Neither side identifies what it ran. Nothing here distinguishes the
+		// two, and the cell-level rules still apply.
+	case bInv == cInv:
+	case bInv == "" || cInv == "":
+		// One side names the command it ran and the other does not. In command
+		// mode the invocation *is* the test; without it on both sides there is
+		// no showing that the same test was executed twice, and dropping the
+		// field must not be a cheaper route to a comparison than keeping it.
+		return "the command under test cannot be shown to be the same: only one report records an invocation_sha256, so it is not established that both runs executed the same test", true
+	default:
 		return "the command under test changed between reports (different invocation_sha256); every cell is inconclusive because the two runs answer different questions", true
 	}
-	if b.ExpectedExitCode != c.ExpectedExitCode {
+
+	// expected_exit_code is a plain int, so a deleted field and an explicit 0
+	// decode identically -- and 0 is the commonest real value, which makes
+	// deletion a quiet way to match any baseline that expects success. Presence
+	// is carried from the raw JSON for exactly that reason.
+	switch {
+	case !baseline.commandExitCodePresent && !candidate.commandExitCodePresent:
+	case baseline.commandExitCodePresent != candidate.commandExitCodePresent:
+		return "the command success contract cannot be shown to be the same: only one report records an expected_exit_code", true
+	case b.ExpectedExitCode != c.ExpectedExitCode:
 		return fmt.Sprintf(
 			"the command success contract changed between reports (expected exit code %d at baseline, %d in the candidate); every cell is inconclusive",
 			b.ExpectedExitCode, c.ExpectedExitCode), true
@@ -399,15 +438,29 @@ func obligationChanged(b, c CellSide) (string, bool) {
 		{"kernel family", b.ProfileKernelFamily, c.ProfileKernelFamily},
 	} {
 		base, cand := strings.TrimSpace(f.base), strings.TrimSpace(f.cand)
-		// Both sides must say, or there is nothing to compare -- an absent
-		// field is unknown, and unknown is handled by the environment rules
-		// rather than being read as a change.
-		if base == "" || cand == "" || base == cand {
+		switch {
+		case base == "" && cand == "":
+			// Neither side states this dimension. That is the shape of older
+			// evidence, which predates the field entirely, and refusing it
+			// would confuse age with tampering. Such a cell is still governed
+			// by every other rule -- in particular an older report carries no
+			// environment evidence either, so it cannot be conclusive anyway.
 			continue
+		case base == cand:
+			continue
+		case base == "" || cand == "":
+			// One side states it and the other does not. Equivalence cannot be
+			// established, and deleting a field must never be an easier route
+			// to a comparison than keeping it: this is the mutation that turned
+			// a changed architecture into an unchanged one.
+			return fmt.Sprintf(
+				"the obligation cannot be shown to be the same: %s is %q at baseline and %q in the candidate, and one side does not say",
+				f.name, base, cand), true
+		default:
+			return fmt.Sprintf(
+				"the obligation changed: this profile names %s %s at baseline and %s in the candidate, so the two results are about different environments",
+				f.name, base, cand), true
 		}
-		return fmt.Sprintf(
-			"the obligation changed: this profile names %s %s at baseline and %s in the candidate, so the two results are about different environments",
-			f.name, base, cand), true
 	}
 	return "", false
 }
@@ -420,12 +473,26 @@ func obligationChanged(b, c CellSide) (string, bool) {
 // candidate cannot inherit the deeper baseline's green.
 func validationDepthChanged(b, c CellSide) (string, bool) {
 	base, cand := strings.TrimSpace(b.AttachMode), strings.TrimSpace(c.AttachMode)
-	if base == "" || cand == "" || base == cand {
+	switch {
+	case base == "" && cand == "":
+		// Neither side records how much of the contract it exercised. Older
+		// evidence looks like this, and it is left to the other rules.
 		return "", false
+	case base == cand:
+		return "", false
+	case base == "" || cand == "":
+		// A candidate that does not say how much it tested cannot inherit a
+		// baseline that does. Losing the evidence and exercising less of the
+		// contract are indistinguishable from here, and neither supports the
+		// baseline's claim.
+		return fmt.Sprintf(
+			"the validation contract cannot be shown to be the same: attach mode %q at baseline and %q in the candidate, and one side does not say",
+			base, cand), true
+	default:
+		return fmt.Sprintf(
+			"the validation contract changed: attach mode %q at baseline and %q in the candidate, so the two runs exercised different amounts of the contract",
+			base, cand), true
 	}
-	return fmt.Sprintf(
-		"the validation contract changed: attach mode %q at baseline and %q in the candidate, so the two runs exercised different amounts of the contract",
-		base, cand), true
 }
 
 func refOf(r schema.ReportV01, path string) ReportRef {
@@ -571,7 +638,7 @@ func Build(baselineEv, candidateEv Evidence, generatedAt string) (Diff, error) {
 			"loader contract changed between reports (baseline=%s candidate=%s); every cell is inconclusive because the comparison would not be like-for-like",
 			d.Baseline.LoaderMode, d.Candidate.LoaderMode))
 	}
-	if note, changed := commandContractChanged(baseline, candidate); changed {
+	if note, changed := commandContractChanged(baselineEv, candidateEv); changed {
 		if incomparable == "" {
 			incomparable = note
 		}

--- a/internal/regressiondiff/diff_test.go
+++ b/internal/regressiondiff/diff_test.go
@@ -283,8 +283,12 @@ func TestLoaderContractChangeMakesEveryCellInconclusive(t *testing.T) {
 func TestChangedObligationIsInconclusive(t *testing.T) {
 	C := schema.VerdictCompatible
 	base := target("k", C, true)
+	// The profile now promises a different series, and honestly ran it: the
+	// recorded match must stay consistent with its own inputs, or the report is
+	// refused as forged before the obligation guard is ever reached.
 	cand := target("k", C, true)
-	cand.Environment.RequestedKernelFamily = "6.1" // the profile now promises a different series
+	cand.Environment.RequestedKernelFamily = "6.1"
+	cand.Environment.ObservedKernel = "6.1.0-27-amd64"
 	d := build(t, report(base), report(cand))
 	cell := onlyCell(t, d)
 	if cell.Classification != Inconclusive {

--- a/internal/regressiondiff/evidence.go
+++ b/internal/regressiondiff/evidence.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"os"
 	"strings"
+	"unicode"
 
 	"github.com/kernel-guard/bpfcompat/pkg/schema"
 )
@@ -296,9 +297,36 @@ func scanForDuplicateKeys(dec *json.Decoder, path string, depth int) error {
 }
 
 // foldKey normalises a JSON object key the way encoding/json compares one when
-// it falls back from an exact match. strings.EqualFold and the decoder's own
-// fold both walk Unicode simple folding, so folding to lower case here groups
-// exactly the spellings the decoder would treat as one field.
+// it falls back from an exact match.
+//
+// Lower-casing is not that rule and misses real collisions: the decoder folds
+// through Unicode simple folding, where U+017F LATIN SMALL LETTER LONG S is in
+// the same orbit as 's'. `{"status":"fail","ſtatus":"pass"}` therefore decodes
+// to status "pass" -- the long-s key binds to Status and overwrites it -- while
+// strings.ToLower sees two unrelated keys. That is the alias bypass again in a
+// spelling nobody types by accident.
+//
+// Each rune is replaced by the smallest member of its simple-fold orbit, which
+// gives one canonical form per group of spellings the decoder cannot tell
+// apart: 's', 'S' and 'ſ' all become 'S', and 'k', 'K' and U+212A KELVIN SIGN
+// all become 'K'. TestFoldKeyMatchesDecoderBinding holds this to the decoder's
+// actual behaviour rather than to this description of it.
+//
+// Folding per rune keeps the scan linear in the document. Comparing every pair
+// of keys with strings.EqualFold would express the same rule, but a single
+// object with many keys would then cost quadratic time -- a denial of service
+// in the component whose job is to survive hostile input.
 func foldKey(key string) string {
-	return strings.ToLower(key)
+	var b strings.Builder
+	b.Grow(len(key))
+	for _, r := range key {
+		canonical := r
+		for f := unicode.SimpleFold(r); f != r; f = unicode.SimpleFold(f) {
+			if f < canonical {
+				canonical = f
+			}
+		}
+		b.WriteRune(canonical)
+	}
+	return b.String()
 }

--- a/internal/regressiondiff/evidence.go
+++ b/internal/regressiondiff/evidence.go
@@ -41,6 +41,13 @@ type Evidence struct {
 	// requiredPresent is parallel to Report.Targets: true when that target
 	// actually carried a `required` field with a boolean value.
 	requiredPresent []bool
+
+	// commandExitCodePresent is true when a command-mode report actually
+	// carried `command.expected_exit_code`. The field is a plain int, so an
+	// absent one and an explicit 0 are the same Go value, and 0 is the
+	// commonest real success contract -- deleting it would otherwise match any
+	// baseline expecting success.
+	commandExitCodePresent bool
 }
 
 // EvidenceFromReport wraps an already-constructed report.
@@ -54,7 +61,12 @@ func EvidenceFromReport(r schema.ReportV01, path, side string) Evidence {
 	for i := range present {
 		present[i] = true
 	}
-	return Evidence{Report: r, Path: path, Side: side, requiredPresent: present}
+	return Evidence{
+		Report: r, Path: path, Side: side, requiredPresent: present,
+		// A caller holding the struct stated the value definitely, in command
+		// mode or not; absence is a JSON-level concept only.
+		commandExitCodePresent: r.Command != nil,
+	}
 }
 
 // LoadEvidence reads and validates one evidence file.
@@ -89,11 +101,13 @@ func LoadEvidence(path, side string) (Evidence, error) {
 		return Evidence{}, fmt.Errorf("parse report %s: %w", path, err)
 	}
 
+	presentRequired, presentExitCode := rawPresence(blob, len(report.Targets))
 	ev := Evidence{
-		Report:          report,
-		Path:            path,
-		Side:            side,
-		requiredPresent: requiredPresence(blob, len(report.Targets)),
+		Report:                 report,
+		Path:                   path,
+		Side:                   side,
+		requiredPresent:        presentRequired,
+		commandExitCodePresent: presentExitCode,
 	}
 	if err := Validate(report, side); err != nil {
 		return Evidence{}, err
@@ -123,25 +137,37 @@ func readBounded(path string) ([]byte, error) {
 	return blob, nil
 }
 
-// requiredPresence records, for each target, whether `required` was actually
-// written as a boolean. `required: null` counts as absent: it carries no more
-// information than omitting the key.
-func requiredPresence(blob []byte, targets int) []bool {
+// rawPresence recovers the two facts the decoded struct cannot hold: whether
+// each target wrote `required`, and whether a command-mode report wrote
+// `expected_exit_code`. Both are fields whose absence is indistinguishable from
+// a meaningful zero value, and both change a release decision.
+//
+// Deliberately two named fields rather than a general presence engine: these
+// are the only release-decision fields where absence is invisible after
+// decoding. Every other one is a pointer, a string that is empty when absent,
+// or a slice.
+//
+// A `null` counts as absent throughout -- it carries no more information than
+// omitting the key.
+func rawPresence(blob []byte, targets int) (required []bool, commandExitCode bool) {
 	var shallow struct {
 		Targets []struct {
 			Required *bool `json:"required"`
 		} `json:"targets"`
+		Command *struct {
+			ExpectedExitCode *int `json:"expected_exit_code"`
+		} `json:"command"`
 	}
-	present := make([]bool, targets)
+	required = make([]bool, targets)
 	if err := json.Unmarshal(blob, &shallow); err != nil {
-		return present
+		return required, false
 	}
-	for i := range present {
+	for i := range required {
 		if i < len(shallow.Targets) && shallow.Targets[i].Required != nil {
-			present[i] = true
+			required[i] = true
 		}
 	}
-	return present
+	return required, shallow.Command != nil && shallow.Command.ExpectedExitCode != nil
 }
 
 // validatePresence refuses evidence that never states a target's requiredness.
@@ -163,8 +189,8 @@ func (e Evidence) validatePresence() error {
 	return nil
 }
 
-// rejectDuplicateKeys refuses a document containing the same key twice in one
-// object, at any depth.
+// rejectDuplicateKeys refuses a document containing two keys in one object that
+// encoding/json can bind to the same field, at any depth.
 //
 // encoding/json accepts duplicates and keeps the last value, so
 // `"verdict":"INCOMPATIBLE","verdict":"COMPATIBLE"` parses as COMPATIBLE while
@@ -173,6 +199,24 @@ func (e Evidence) validatePresence() error {
 // duplicated field that is evidence of anything. The rule is deliberately
 // blanket rather than a list of fields that matter: an exemption list is a
 // place for the next contract field to be forgotten.
+//
+// Exact spelling is not the boundary, because it is not where encoding/json
+// draws it. Struct field matching prefers an exact tag match and then falls
+// back to a case-insensitive one, so `"verdict"` and `"Verdict"` in the same
+// object both bind to Verdict and the later one wins. Measured against the real
+// schema types: `verdict`/`Verdict`/`VERDICT`/`vErDiCt` collide, as do
+// `profile_id`/`PROFILE_ID`, `required`/`Required`, `summary`/`Summary` and
+// `targets`/`Targets`. Removing the underscore (`profileid`) or spelling the Go
+// field name (`ProfileID`) does not collide, so no such transformation is
+// applied here -- the rule matches the decoder's behaviour and nothing more.
+//
+// Keys are therefore compared case-folded, exactly as the decoder compares
+// them. This does mean two unrelated extension keys differing only in case are
+// refused; the alternative is a path-aware model of which objects are structs,
+// which is the schema written twice and wrong the first time a field is added.
+// A producer emitting `foo` and `Foo` side by side in one object is writing
+// evidence whose meaning depends on decoder internals, which is precisely what
+// this refuses.
 func rejectDuplicateKeys(blob []byte) error {
 	dec := json.NewDecoder(bytes.NewReader(blob))
 	dec.UseNumber()
@@ -207,7 +251,9 @@ func scanForDuplicateKeys(dec *json.Decoder, path string, depth int) error {
 	}
 	switch delim {
 	case '{':
-		seen := make(map[string]struct{})
+		// Keyed by the folded name, holding the spelling first seen, so the
+		// error can show both spellings of a collision.
+		seen := make(map[string]string)
 		for dec.More() {
 			keyTok, err := dec.Token()
 			if err != nil {
@@ -221,10 +267,15 @@ func scanForDuplicateKeys(dec *json.Decoder, path string, depth int) error {
 			if path != "" {
 				child = path + "." + key
 			}
-			if _, dup := seen[key]; dup {
-				return fmt.Errorf("the JSON key %q appears twice in the same object; which value the release decision would be made from is ambiguous", child)
+			folded := foldKey(key)
+			if first, dup := seen[folded]; dup {
+				if first == key {
+					return fmt.Errorf("the JSON key %q appears twice in the same object; which value the release decision would be made from is ambiguous", child)
+				}
+				return fmt.Errorf("the JSON keys %q and %q appear in the same object and decode to the same field (field matching is case-insensitive), so which value the release decision would be made from is ambiguous",
+					first, key)
 			}
-			seen[key] = struct{}{}
+			seen[folded] = key
 			if err := scanForDuplicateKeys(dec, child, depth+1); err != nil {
 				return err
 			}
@@ -242,4 +293,12 @@ func scanForDuplicateKeys(dec *json.Decoder, path string, depth int) error {
 		return errMalformedJSON
 	}
 	return nil
+}
+
+// foldKey normalises a JSON object key the way encoding/json compares one when
+// it falls back from an exact match. strings.EqualFold and the decoder's own
+// fold both walk Unicode simple folding, so folding to lower case here groups
+// exactly the spellings the decoder would treat as one field.
+func foldKey(key string) string {
+	return strings.ToLower(key)
 }

--- a/internal/regressiondiff/fuzz_test.go
+++ b/internal/regressiondiff/fuzz_test.go
@@ -105,6 +105,15 @@ func FuzzLoadEvidence(f *testing.F) {
 		strings.Replace(valid, `"kernel_family_match":true`, `"kernel_family_match":null`, 1),
 		strings.Repeat("[", 200) + strings.Repeat("]", 200),
 		"\x00\x01\x02",
+		// Gate 2.1 boundaries.
+		strings.Replace(valid, `"verdict":"COMPATIBLE"`, `"verdict":"INCOMPATIBLE","Verdict":"COMPATIBLE"`, 1),
+		strings.Replace(valid, `"status":"pass"`, `"status":"fail","Status":"pass"`, 1),
+		strings.Replace(valid, `"required":true`, `"required":true,"Required":false`, 1),
+		strings.Replace(valid, `"profile_id":"k"`, `"profile_id":"k","PROFILE_ID":"other"`, 1),
+		// A kernel series nothing tested, asserted as established.
+		strings.Replace(valid, `"requested_kernel_family":"5.15"`, `"requested_kernel_family":"4.18"`, 1),
+		strings.Replace(valid, `"kernel_family_match":true`, `"kernel_family_match":false`, 1),
+		strings.Replace(valid, `"observed_kernel":"5.15.0-1"`, `"observed_kernel":"unknown"`, 1),
 	} {
 		f.Add(seed)
 	}
@@ -158,6 +167,30 @@ func FuzzCompareNeverGreensUnestablishedEvidence(f *testing.F) {
 	f.Add(mk("a", "COMPATIBLE", "pass", true, goodEnv), mk("a", "COMPATIBLE", "pass", true, goodEnv))
 	f.Add(`{}`, `{}`)
 	f.Add(``, mk("b", "COMPATIBLE", "pass", true, goodEnv))
+
+	// Gate 2.1 boundaries, as pairs.
+	forgedEnv := `,"environment":{"requested_kernel_family":"4.18","observed_kernel":"5.15.0-1","kernel_family_match":true}`
+	aliased := strings.Replace(mk("b", "INCOMPATIBLE", "fail", true, goodEnv),
+		`"verdict":"INCOMPATIBLE"`, `"verdict":"INCOMPATIBLE","Verdict":"COMPATIBLE"`, 1)
+	f.Add(mk("a", "COMPATIBLE", "pass", true, goodEnv), aliased)
+	f.Add(mk("a", "COMPATIBLE", "pass", true, goodEnv), mk("b", "COMPATIBLE", "pass", true, forgedEnv))
+	f.Add(mk("a", "COMPATIBLE", "pass", true, forgedEnv), mk("b", "INCOMPATIBLE", "fail", true, goodEnv))
+
+	// One-sided obligation and command identity.
+	profiled := func(runID, profile string) string {
+		return fmt.Sprintf(`{"schema_version":"v0.1","run":{"id":%q},"targets":[{"profile_id":"k","required":true,"status":"pass","verdict":"COMPATIBLE"%s%s}],"summary":{}}`,
+			runID, goodEnv, profile)
+	}
+	withProfile := `,"profile":{"arch":"x86_64","distro":"rhel","version":"9","kernel_family":"5.15"}`
+	f.Add(profiled("a", withProfile), profiled("b", ""))
+	f.Add(profiled("a", ""), profiled("b", withProfile))
+
+	cmd := func(runID, invocation, exitCode string) string {
+		return fmt.Sprintf(`{"schema_version":"v0.1","run":{"id":%q},"command":{%s%s"binary":{"sha256":"L"}},"targets":[{"profile_id":"k","required":true,"status":"pass","verdict":"COMPATIBLE"%s}],"summary":{}}`,
+			runID, invocation, exitCode, goodEnv)
+	}
+	f.Add(cmd("a", `"invocation_sha256":"inv",`, `"expected_exit_code":0,`), cmd("b", ``, `"expected_exit_code":0,`))
+	f.Add(cmd("a", `"invocation_sha256":"inv",`, `"expected_exit_code":0,`), cmd("b", `"invocation_sha256":"inv",`, ``))
 
 	f.Fuzz(func(t *testing.T, baseline, candidate string) {
 		dir := t.TempDir()
@@ -356,4 +389,114 @@ func TestIrrelevantNoiseDoesNotChangeTheDecision(t *testing.T) {
 	if got.Summary.NewRequiredRegressions != 1 {
 		t.Fatalf("the regression was lost under noise: %+v", got.Summary)
 	}
+}
+
+// ---------------------------------------------------------------------------
+// Gate 2.1: weakening evidence must never buy a greener answer
+// ---------------------------------------------------------------------------
+
+// fullTarget carries every dimension the comparison reads, so that deleting or
+// aliasing any one of them is a real mutation rather than a no-op.
+func fullTarget(id, verdict string, required bool) schema.Target {
+	tg := target(id, verdict, required)
+	tg.Profile = &schema.TargetEnv{Distro: "rhel", Version: "9", KernelFamily: "5.15", Arch: "x86_64"}
+	tg.Validation = &schema.Validation{AttachMode: "best-effort", LoadStatus: "ok"}
+	return tg
+}
+
+// The Gate 2.1 property, stated the way the contract is: removing, aliasing or
+// contradicting semantic evidence can never turn a non-green comparison into a
+// green one, and can never leave a green one resting on less than it did.
+func TestWeakeningEvidenceNeverBuysGreen(t *testing.T) {
+	C, I, E := schema.VerdictCompatible, schema.VerdictIncompatible, schema.VerdictInfraError
+
+	scenarios := map[string][2]schema.Target{
+		"proven regression":    {fullTarget("k", C, true), fullTarget("k", I, true)},
+		"unchanged compatible": {fullTarget("k", C, true), fullTarget("k", C, true)},
+		"unproven baseline":    {fullTarget("k", E, true), fullTarget("k", I, true)},
+		"optional obligation":  {fullTarget("k", C, false), fullTarget("k", I, false)},
+		"changed architecture": {fullTarget("k", C, true), func() schema.Target {
+			tg := fullTarget("k", C, true)
+			tg.Profile.Arch = "arm64"
+			return tg
+		}()},
+	}
+
+	// Each mutation is something a truncating artifact step, a hand edit or a
+	// hostile PR author can do to the raw JSON.
+	mutations := []struct{ name, find, replace string }{
+		{"profile arch deleted", `"arch": "x86_64"`, `"unused_arch": "x86_64"`},
+		{"profile arch emptied", `"arch": "x86_64"`, `"arch": ""`},
+		{"distro deleted", `"distro": "rhel",`, ``},
+		{"distro version deleted", `"version": "9",`, ``},
+		{"profile kernel family deleted", `"kernel_family": "5.15",`, ``},
+		{"whole profile block deleted", `"profile": {`, `"unused_profile": {`},
+		{"attach mode deleted", `"attach_mode": "best-effort",`, ``},
+		{"whole validation block deleted", `"validation": {`, `"unused_validation": {`},
+		{"environment deleted", `"environment": {`, `"unused_environment": {`},
+		{"kernel_family_match deleted", `"kernel_family_match": true`, `"unused_match": true`},
+		{"kernel_family_match flipped", `"kernel_family_match": true`, `"kernel_family_match": false`},
+		{"observed kernel deleted", `"observed_kernel": "5.15.0-186-generic",`, ``},
+		{"verdict aliased to COMPATIBLE", `"verdict": "INCOMPATIBLE"`, `"verdict": "INCOMPATIBLE", "Verdict": "COMPATIBLE"`},
+		{"status aliased to pass", `"status": "fail"`, `"status": "fail", "Status": "pass"`},
+		{"required aliased to false", `"required": true`, `"required": true, "Required": false`},
+		{"required deleted", `"required": true,`, ``},
+		{"verdict deleted", `"verdict": "`, `"unused_verdict": "`},
+	}
+
+	for name, pair := range scenarios {
+		baseJSON := jsonOf(t, report(pair[0]))
+		candJSON := jsonOf(t, report(pair[1]))
+		original, originalExit, originalErr := compareFiles(t, baseJSON, candJSON)
+		originalGreen := originalErr == nil && originalExit == ExitNoRegressions
+
+		for _, side := range []string{"baseline", "candidate"} {
+			for _, m := range mutations {
+				t.Run(fmt.Sprintf("%s/%s/%s", name, side, m.name), func(t *testing.T) {
+					mutatedBase, mutatedCand := baseJSON, candJSON
+					if side == "baseline" {
+						mutatedBase = strings.Replace(baseJSON, m.find, m.replace, 1)
+					} else {
+						mutatedCand = strings.Replace(candJSON, m.find, m.replace, 1)
+					}
+					if mutatedBase == baseJSON && mutatedCand == candJSON {
+						t.Skip("mutation does not apply to this fixture")
+					}
+
+					d, exit, err := compareFiles(t, mutatedBase, mutatedCand)
+					if err != nil {
+						return // refused: the strongest form of not-green
+					}
+					if exit == ExitNoRegressions {
+						if !originalGreen {
+							t.Fatalf("weakened evidence turned %s (exit %d) into a green result",
+								original.Summary.Result, originalExit)
+						}
+						// Still green: it must still be resting on established
+						// required evidence, not on what the mutation removed.
+						exitZeroRequiresEstablishedRequiredEvidence(t, d, name+"/"+m.name)
+					}
+					requiredRegressionsAreProven(t, d, name+"/"+m.name)
+				})
+			}
+		}
+	}
+}
+
+// Invariant C, restated for Gate 2.1: a required regression must still rest on
+// two proven results after every one of those mutations. Covered above by
+// requiredRegressionsAreProven; this pins the headline case explicitly so a
+// regression in the rule is not hidden among skips.
+func TestProvenRegressionSurvivesGateTwoOneRules(t *testing.T) {
+	C, I := schema.VerdictCompatible, schema.VerdictIncompatible
+	d, exit, err := compareFiles(t,
+		jsonOf(t, report(fullTarget("k", C, true))),
+		jsonOf(t, report(fullTarget("k", I, true))))
+	if err != nil {
+		t.Fatalf("complete, honest evidence must still compare: %v", err)
+	}
+	if exit != ExitRegressed || d.Summary.NewRequiredRegressions != 1 {
+		t.Fatalf("want a gating regression, got exit %d summary %+v", exit, d.Summary)
+	}
+	requiredRegressionsAreProven(t, d, "headline")
 }

--- a/internal/regressiondiff/trust21_test.go
+++ b/internal/regressiondiff/trust21_test.go
@@ -493,3 +493,115 @@ func TestOlderEvidenceRemainsReadableAndInconclusive(t *testing.T) {
 		t.Fatalf("want exit %d, got %d", ExitInconclusive, exit)
 	}
 }
+
+// The fold rule must be the decoder's rule, not a description of it. For every
+// spelling below, "foldKey groups these two keys" and "the decoder binds both
+// to one field" have to be the same answer -- in both directions. Lower-casing
+// passed the ASCII half of this table and failed the rest.
+func TestFoldKeyMatchesDecoderBinding(t *testing.T) {
+	for _, tc := range []struct{ name, a, bKey string }{
+		{"identical", "status", "status"},
+		{"leading capital", "status", "Status"},
+		{"all caps", "verdict", "VERDICT"},
+		{"mixed case", "verdict", "vErDiCt"},
+		{"underscore kept", "profile_id", "PROFILE_ID"},
+		// Unicode simple folding: these bind, and a lower-case fold misses them.
+		{"long s", "status", "ſtatus"},
+		{"kelvin sign", "kernel_family_match", "Kernel_family_match"},
+		// Must NOT be grouped: the decoder does not bind these.
+		{"underscore removed", "profile_id", "profileid"},
+		{"go field name", "profile_id", "ProfileID"},
+		{"different word", "status", "statuses"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			grouped := foldKey(tc.a) == foldKey(tc.bKey)
+
+			// What the decoder actually does with both keys in one object: if
+			// the second binds to the same field, it overwrites the first.
+			blob := fmt.Sprintf(`{%q:%q,%q:%q}`, tc.a, "first", tc.bKey, "second")
+			var into map[string]string
+			if err := json.Unmarshal([]byte(blob), &into); err != nil {
+				t.Fatal(err)
+			}
+			binds := decoderBinds(t, tc.a, tc.bKey)
+
+			if grouped != binds {
+				t.Fatalf("foldKey groups=%v but the decoder binds=%v for %q/%q; the rule does not match the decoder",
+					grouped, binds, tc.a, tc.bKey)
+			}
+		})
+	}
+}
+
+// decoderBinds reports whether encoding/json resolves two spellings to one
+// struct field, asked of a struct whose only tagged field is the first
+// spelling.
+func decoderBinds(t *testing.T, tag, other string) bool {
+	t.Helper()
+	blob := fmt.Sprintf(`{%q:%q}`, other, "second")
+	switch tag {
+	case "status":
+		var v struct {
+			Status string `json:"status"`
+		}
+		if err := json.Unmarshal([]byte(blob), &v); err != nil {
+			t.Fatal(err)
+		}
+		return v.Status == "second"
+	case "verdict":
+		var v struct {
+			Verdict string `json:"verdict"`
+		}
+		if err := json.Unmarshal([]byte(blob), &v); err != nil {
+			t.Fatal(err)
+		}
+		return v.Verdict == "second"
+	case "profile_id":
+		var v struct {
+			ProfileID string `json:"profile_id"`
+		}
+		if err := json.Unmarshal([]byte(blob), &v); err != nil {
+			t.Fatal(err)
+		}
+		return v.ProfileID == "second"
+	case "kernel_family_match":
+		var v struct {
+			KernelFamilyMatch string `json:"kernel_family_match"`
+		}
+		if err := json.Unmarshal([]byte(blob), &v); err != nil {
+			t.Fatal(err)
+		}
+		return v.KernelFamilyMatch == "second"
+	default:
+		t.Fatalf("no probe for tag %q", tag)
+		return false
+	}
+}
+
+// End to end: the long-s spelling must be refused like any other alias.
+func TestUnicodeFoldedAliasIsRefused(t *testing.T) {
+	base, _ := greenPair(t)
+	valid := jsonOf(t, report(target("k", schema.VerdictIncompatible, true)))
+	forged := strings.Replace(valid, `"status": "fail",`,
+		"\"status\": \"fail\", \"ſtatus\": \"pass\",", 1)
+	if forged == valid {
+		t.Fatal("fixture did not mutate")
+	}
+
+	// The bypass is only interesting if the decoder really binds it.
+	var probe schema.Target
+	if err := json.Unmarshal([]byte(`{"status":"fail","`+"ſ"+`tatus":"pass"}`), &probe); err != nil {
+		t.Fatal(err)
+	}
+	if probe.Status != "pass" {
+		t.Skip("this Go version does not fold U+017F into ASCII s")
+	}
+
+	d, exit, err := compareFiles(t, base, forged)
+	if err == nil {
+		t.Fatalf("a Unicode-folded alias was accepted as %s", d.Summary.Result)
+	}
+	if exit != ExitInconclusive {
+		t.Fatalf("want exit %d, got %d", ExitInconclusive, exit)
+	}
+}

--- a/internal/regressiondiff/trust21_test.go
+++ b/internal/regressiondiff/trust21_test.go
@@ -1,0 +1,495 @@
+package regressiondiff
+
+import (
+	"encoding/json"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/kernel-guard/bpfcompat/pkg/schema"
+)
+
+// The second trust-boundary pass. Gate 2 refused evidence that contradicted
+// itself in the obvious spellings; these are the four ways a report could still
+// be made to say one thing and decode as another, or to buy a comparison by
+// deleting what proves the two runs were about the same thing.
+
+// ---------------------------------------------------------------------------
+// JSON field aliases
+// ---------------------------------------------------------------------------
+
+// The decoder's real behaviour, pinned. Everything the alias rule does follows
+// from this test rather than from an assumption about how Go matches fields: an
+// exact tag match is preferred and then a case-insensitive one, so two keys
+// that differ only in case bind to one field and the later wins. Removing the
+// underscore or spelling the Go field name does not bind, so the rule does not
+// pretend it does.
+func TestDecoderAliasBehaviourIsWhatTheRuleAssumes(t *testing.T) {
+	for _, tc := range []struct {
+		name, blob, want string
+	}{
+		{"later case variant wins", `{"verdict":"INCOMPATIBLE","Verdict":"COMPATIBLE"}`, "COMPATIBLE"},
+		{"order decides which wins", `{"Verdict":"COMPATIBLE","verdict":"INCOMPATIBLE"}`, "INCOMPATIBLE"},
+		{"upper case binds", `{"verdict":"INCOMPATIBLE","VERDICT":"COMPATIBLE"}`, "COMPATIBLE"},
+		{"mixed case binds", `{"verdict":"INCOMPATIBLE","vErDiCt":"COMPATIBLE"}`, "COMPATIBLE"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var tg schema.Target
+			if err := json.Unmarshal([]byte(tc.blob), &tg); err != nil {
+				t.Fatal(err)
+			}
+			if tg.Verdict != tc.want {
+				t.Fatalf("decoder bound %q, test assumed %q", tg.Verdict, tc.want)
+			}
+		})
+	}
+
+	// The negative half of the assumption, which is why the rule is a case
+	// fold and not a looser normalisation.
+	for _, tc := range []struct{ name, blob, want string }{
+		{"underscore removed does not bind", `{"profile_id":"a","profileid":"b"}`, "a"},
+		{"Go field name does not bind", `{"profile_id":"a","ProfileID":"b"}`, "a"},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			var tg schema.Target
+			if err := json.Unmarshal([]byte(tc.blob), &tg); err != nil {
+				t.Fatal(err)
+			}
+			if tg.ProfileID != tc.want {
+				t.Fatalf("decoder bound %q, test assumed %q -- the alias rule would be wrong", tg.ProfileID, tc.want)
+			}
+		})
+	}
+}
+
+func TestAliasedKeysAreRefused(t *testing.T) {
+	base, _ := greenPair(t)
+	valid := jsonOf(t, report(target("k", schema.VerdictIncompatible, true)))
+
+	for _, tc := range []struct {
+		name, find, replace string
+	}{
+		{"exact duplicate still refused", `"verdict": "INCOMPATIBLE"`, `"verdict": "INCOMPATIBLE",` + "\n" + `  "verdict": "COMPATIBLE"`},
+		{"verdict and Verdict", `"verdict": "INCOMPATIBLE"`, `"verdict": "INCOMPATIBLE",` + "\n" + `  "Verdict": "COMPATIBLE"`},
+		{"status and Status", `"status": "fail"`, `"status": "fail",` + "\n" + `  "Status": "pass"`},
+		{"required and Required", `"required": true`, `"required": true,` + "\n" + `  "Required": false`},
+		{"profile_id and PROFILE_ID", `"profile_id": "k"`, `"profile_id": "k",` + "\n" + `  "PROFILE_ID": "other"`},
+		{"nested kernel_family_match", `"kernel_family_match": true`, `"kernel_family_match": true,` + "\n" + `   "Kernel_Family_Match": false`},
+		{"report-level summary", `"summary": {`, `"Summary": {"verdict": "COMPATIBLE"},` + "\n" + ` "summary": {`},
+		{"report-level targets", `"targets": [`, `"Targets": [],` + "\n" + ` "targets": [`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			mutated := strings.Replace(valid, tc.find, tc.replace, 1)
+			if mutated == valid {
+				t.Fatalf("fixture did not mutate; looked for %q", tc.find)
+			}
+			_, exit, err := compareFiles(t, base, mutated)
+			if err == nil {
+				t.Fatal("two keys the decoder binds to one field are ambiguous evidence")
+			}
+			if exit != ExitInconclusive {
+				t.Fatalf("want exit %d, got %d", ExitInconclusive, exit)
+			}
+		})
+	}
+}
+
+// The whole point, end to end: a report that reads INCOMPATIBLE on every line a
+// human would look at, and decodes to COMPATIBLE. Before the alias rule this
+// produced NO_NEW_REGRESSIONS and exit 0.
+func TestAliasingCannotTurnAnIncompatibleTargetIntoGreenEvidence(t *testing.T) {
+	base, _ := greenPair(t)
+	forged := jsonOf(t, report(target("k", schema.VerdictIncompatible, true)))
+	// Every derived field made consistent with the aliased values, so nothing
+	// but the alias rule can catch it.
+	for find, replace := range map[string]string{
+		`"status": "fail",`:                `"status": "fail", "Status": "pass",`,
+		`"verdict": "INCOMPATIBLE",`:       `"verdict": "INCOMPATIBLE", "Verdict": "COMPATIBLE",`,
+		`"verdict": "INCOMPATIBLE"` + "\n": `"verdict": "INCOMPATIBLE", "Verdict": "COMPATIBLE"` + "\n",
+	} {
+		forged = strings.ReplaceAll(forged, find, replace)
+	}
+	if !strings.Contains(forged, `"Verdict"`) {
+		t.Fatal("fixture did not acquire an alias")
+	}
+
+	d, exit, err := compareFiles(t, base, forged)
+	if err == nil {
+		t.Fatalf("a report whose meaning depends on decoder internals was accepted as %s", d.Summary.Result)
+	}
+	if exit != ExitInconclusive {
+		t.Fatalf("want exit %d, got %d", ExitInconclusive, exit)
+	}
+}
+
+// Fail-closed must not mean fail-on-everything: ordinary distinct keys, and
+// extension fields a future producer might add, still decode.
+func TestUnrelatedKeysAreStillAccepted(t *testing.T) {
+	base, _ := greenPair(t)
+	valid := jsonOf(t, report(target("k", schema.VerdictCompatible, true)))
+	noisy := strings.Replace(valid, `"profile_id": "k",`,
+		`"profile_id": "k", "vendor_note": "x", "vendorNote": "y", "future_field": 1,`, 1)
+	if noisy == valid {
+		t.Fatal("fixture did not mutate")
+	}
+	d, exit, err := compareFiles(t, base, noisy)
+	if err != nil {
+		t.Fatalf("unrelated keys must not be refused: %v", err)
+	}
+	if exit != ExitNoRegressions || d.Summary.Result != ResultNoRegressions {
+		t.Fatalf("want a clean comparison, got %s/exit %d", d.Summary.Result, exit)
+	}
+}
+
+// ---------------------------------------------------------------------------
+// kernel_family_match is verified, not believed
+// ---------------------------------------------------------------------------
+
+func envTarget(t *testing.T, requested, observed string, match *bool) schema.Target {
+	t.Helper()
+	tg := target("k", schema.VerdictCompatible, true)
+	tg.Environment = &schema.EnvironmentCheck{
+		RequestedKernelFamily: requested,
+		ObservedKernel:        observed,
+		KernelFamilyMatch:     match,
+	}
+	return tg
+}
+
+func TestRecordedKernelFamilyMatchMustAgreeWithItsOwnInputs(t *testing.T) {
+	yes, no := true, false
+
+	for _, tc := range []struct {
+		name                string
+		requested, observed string
+		recorded            *bool
+		wantRefused         bool
+		wantEvidence        string
+	}{
+		{"correct true", "5.15", "5.15.0-186-generic", &yes, false, EnvironmentEstablishedEvidence},
+		{"correct false", "4.18", "5.15.0-206.el8uek", &no, false, EnvironmentMismatchEvidence},
+		{"correct false, different series", "5.15", "6.12.0-107.el9uek.x86_64", &no, false, EnvironmentMismatchEvidence},
+		// The forgery Gate 2 accepted: a kernel series nothing tested, asserted
+		// as established.
+		{"forged true", "4.18", "5.15.0-206.el8uek", &yes, true, ""},
+		{"forged false", "5.15", "5.15.0-186-generic", &no, true, ""},
+		// A boolean whose inputs cannot produce one. The producer would have
+		// left it unset.
+		{"claimed but underivable", "rhel-latest", "unknown", &yes, true, ""},
+		{"claimed but underivable, false", "rhel-latest", "unknown", &no, true, ""},
+		// Absent stays unknown: readable, never established, never a mismatch.
+		{"not recorded", "5.15", "5.15.0-186-generic", nil, false, EnvironmentUnknownEvidence},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			r := report(envTarget(t, tc.requested, tc.observed, tc.recorded))
+			base, _ := greenPair(t)
+			d, exit, err := compareFiles(t, base, jsonOf(t, r))
+
+			if tc.wantRefused {
+				if err == nil {
+					t.Fatalf("an unverifiable environment claim was accepted as %s", d.Summary.Result)
+				}
+				if exit != ExitInconclusive {
+					t.Fatalf("want exit %d, got %d", ExitInconclusive, exit)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("honest evidence was refused: %v", err)
+			}
+			if got := onlyCell(t, d).Candidate.EnvironmentEvidence; got != tc.wantEvidence {
+				t.Fatalf("environment evidence: want %q, got %q", tc.wantEvidence, got)
+			}
+		})
+	}
+}
+
+// The mutation that must make the suite red: flipping the stored boolean while
+// leaving its inputs alone.
+func TestFlippingTheStoredKernelMatchIsDetected(t *testing.T) {
+	base, _ := greenPair(t)
+	honest := jsonOf(t, report(envTarget(t, "5.15", "5.15.0-186-generic", func() *bool { v := true; return &v }())))
+
+	if _, _, err := compareFiles(t, base, honest); err != nil {
+		t.Fatalf("the honest fixture must be accepted first: %v", err)
+	}
+
+	flipped := strings.Replace(honest, `"kernel_family_match": true`, `"kernel_family_match": false`, 1)
+	if flipped == honest {
+		t.Fatal("fixture did not mutate")
+	}
+	_, exit, err := compareFiles(t, base, flipped)
+	if err == nil {
+		t.Fatal("a flipped kernel_family_match must not be believed")
+	}
+	if !strings.Contains(err.Error(), "does not agree with itself") {
+		t.Fatalf("the refusal must name the contradiction: %v", err)
+	}
+	if exit != ExitInconclusive {
+		t.Fatalf("want exit %d, got %d", ExitInconclusive, exit)
+	}
+}
+
+// One source of truth: whatever the producer's primitive records for a real
+// profile/kernel pair, the verifier accepts. If the two ever drift, honest
+// evidence starts being refused, and this fails first.
+func TestProducerRecordedMatchesAlwaysVerify(t *testing.T) {
+	for _, pair := range []struct{ requested, observed string }{
+		{"5.15", "5.15.0-186-generic"},
+		{"5.14", "5.14.0-687.36.1.el9_8.x86_64"},
+		{"4.18", "5.15.0-206.el8uek"},
+		{"6.1", "6.1.155"},
+		{"4.14", "4.14.336-257.562.amzn2.x86_64"},
+		{"6.12", "6.12.0-107.el9uek.x86_64"},
+	} {
+		match, derivable := schema.KernelFamilyMatch(pair.requested, pair.observed)
+		if !derivable {
+			t.Fatalf("%q/%q: a real profile pair must be derivable", pair.requested, pair.observed)
+		}
+		tg := envTarget(t, pair.requested, pair.observed, &match)
+		if err := Validate(report(tg), "candidate"); err != nil {
+			t.Fatalf("%q/%q: producer-recorded evidence was refused by the verifier: %v",
+				pair.requested, pair.observed, err)
+		}
+	}
+}
+
+// ---------------------------------------------------------------------------
+// One-sided loss of contract identity
+// ---------------------------------------------------------------------------
+
+func profiled(arch, distro, version, family string) schema.Target {
+	tg := target("k", schema.VerdictCompatible, true)
+	tg.Profile = &schema.TargetEnv{Arch: arch, Distro: distro, Version: version, KernelFamily: family}
+	return tg
+}
+
+func TestOneSidedObligationMetadataIsInconclusive(t *testing.T) {
+	full := profiled("x86_64", "rhel", "9", "5.14")
+
+	for _, tc := range []struct {
+		name       string
+		base, cand schema.Target
+		wantGreen  bool
+	}{
+		{"arch changed", full, profiled("arm64", "rhel", "9", "5.14"), false},
+		{"arch lost by candidate", full, profiled("", "rhel", "9", "5.14"), false},
+		{"arch only in candidate", profiled("", "rhel", "9", "5.14"), profiled("arm64", "rhel", "9", "5.14"), false},
+		{"distro lost by candidate", full, profiled("x86_64", "", "9", "5.14"), false},
+		{"version lost by candidate", full, profiled("x86_64", "rhel", "", "5.14"), false},
+		{"kernel family lost by candidate", full, profiled("x86_64", "rhel", "9", ""), false},
+		{"whole profile block lost", full, target("k", schema.VerdictCompatible, true), false},
+		// Neither side ever recorded it: older evidence, still comparable.
+		{"neither side records it", target("k", schema.VerdictCompatible, true), target("k", schema.VerdictCompatible, true), true},
+		{"identical obligation", full, full, true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d, exit, err := compareFiles(t, jsonOf(t, report(tc.base)), jsonOf(t, report(tc.cand)))
+			if err != nil {
+				t.Fatalf("missing metadata is unusable evidence, not malformed: %v", err)
+			}
+			cell := onlyCell(t, d)
+			if tc.wantGreen {
+				if cell.Classification != UnchangedCompatible || exit != ExitNoRegressions {
+					t.Fatalf("want a clean comparison, got %s/exit %d (%s)", cell.Classification, exit, cell.Reason)
+				}
+				return
+			}
+			if cell.Classification != Inconclusive {
+				t.Fatalf("want %s, got %s (%s)", Inconclusive, cell.Classification, cell.Reason)
+			}
+			if exit != ExitInconclusive {
+				t.Fatalf("want exit %d, got %d", ExitInconclusive, exit)
+			}
+		})
+	}
+}
+
+// Deleting the candidate's metadata used to convert a changed obligation back
+// into an unchanged one -- weakening the evidence bought a greener answer.
+func TestDeletingObligationMetadataCannotRecoverGreen(t *testing.T) {
+	changed := compareOf(t, profiled("x86_64", "rhel", "9", "5.14"), profiled("arm64", "rhel", "9", "5.14"))
+	if changed != ExitInconclusive {
+		t.Fatalf("precondition: a changed architecture is inconclusive, got exit %d", changed)
+	}
+	deleted := compareOf(t, profiled("x86_64", "rhel", "9", "5.14"), target("k", schema.VerdictCompatible, true))
+	if deleted == ExitNoRegressions {
+		t.Fatal("deleting the candidate's profile metadata turned an inconclusive comparison green")
+	}
+}
+
+func compareOf(t *testing.T, base, cand schema.Target) int {
+	t.Helper()
+	_, exit, err := compareFiles(t, jsonOf(t, report(base)), jsonOf(t, report(cand)))
+	if err != nil {
+		return ExitInconclusive
+	}
+	return exit
+}
+
+func TestOneSidedValidationDepthIsInconclusive(t *testing.T) {
+	withAttach := func(mode string) schema.Target {
+		tg := target("k", schema.VerdictCompatible, true)
+		if mode != "" {
+			tg.Validation = &schema.Validation{AttachMode: mode}
+		}
+		return tg
+	}
+	for _, tc := range []struct {
+		name       string
+		base, cand string
+		wantGreen  bool
+	}{
+		{"candidate lost its attach mode", "best-effort", "", false},
+		{"only the candidate records one", "", "best-effort", false},
+		{"changed attach mode", "best-effort", "disabled", false},
+		{"same attach mode", "best-effort", "best-effort", true},
+		{"neither records one", "", "", true},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d, exit, err := compareFiles(t,
+				jsonOf(t, report(withAttach(tc.base))), jsonOf(t, report(withAttach(tc.cand))))
+			if err != nil {
+				t.Fatalf("unexpected refusal: %v", err)
+			}
+			cell := onlyCell(t, d)
+			if tc.wantGreen {
+				if cell.Classification != UnchangedCompatible || exit != ExitNoRegressions {
+					t.Fatalf("want a clean comparison, got %s/exit %d", cell.Classification, exit)
+				}
+				return
+			}
+			if cell.Classification != Inconclusive || exit != ExitInconclusive {
+				t.Fatalf("want %s/exit %d, got %s/exit %d (%s)",
+					Inconclusive, ExitInconclusive, cell.Classification, exit, cell.Reason)
+			}
+		})
+	}
+}
+
+func commandReport(t *testing.T, invocation string, exitCode *int, loaderSHA string) string {
+	t.Helper()
+	r := report(target("k", schema.VerdictCompatible, true))
+	r.Validator = nil
+	cmd := &schema.CommandInfo{
+		InvocationSHA256: invocation,
+		Binary:           &schema.BinaryIdentity{BaseName: "loader", SHA256: loaderSHA, SizeBytes: 9},
+	}
+	if exitCode != nil {
+		cmd.ExpectedExitCode = *exitCode
+	}
+	r.Command = cmd
+	blob := jsonOf(t, r)
+	if exitCode == nil {
+		// The Go type cannot express an absent int, so the field is removed
+		// from the rendered JSON -- which is exactly the shape under test.
+		blob = strings.Replace(blob, `"expected_exit_code": 0,`, "", 1)
+		blob = strings.Replace(blob, `"expected_exit_code": 0`, "", 1)
+		if strings.Contains(blob, "expected_exit_code") {
+			t.Fatalf("fixture still carries expected_exit_code:\n%s", blob)
+		}
+	}
+	if invocation == "" {
+		blob = strings.Replace(blob, `"invocation_sha256": "",`, "", 1)
+	}
+	return blob
+}
+
+func TestOneSidedCommandContractIdentityIsInconclusive(t *testing.T) {
+	zero, seven := 0, 7
+
+	for _, tc := range []struct {
+		name       string
+		base, cand string
+		wantGreen  bool
+	}{
+		{
+			"same command and success contract",
+			commandReport(t, "inv-A", &zero, "loader-v1"),
+			commandReport(t, "inv-A", &zero, "loader-v2"), // the loader IS the product; it may change
+			true,
+		},
+		{
+			"different command",
+			commandReport(t, "inv-A", &zero, "loader-v1"),
+			commandReport(t, "inv-B", &zero, "loader-v2"),
+			false,
+		},
+		{
+			"candidate lost the command identity",
+			commandReport(t, "inv-A", &zero, "loader-v1"),
+			commandReport(t, "", &zero, "loader-v2"),
+			false,
+		},
+		{
+			"only the candidate records one",
+			commandReport(t, "", &zero, "loader-v1"),
+			commandReport(t, "inv-A", &zero, "loader-v2"),
+			false,
+		},
+		{
+			"different success contract",
+			commandReport(t, "inv-A", &zero, "loader-v1"),
+			commandReport(t, "inv-A", &seven, "loader-v2"),
+			false,
+		},
+		{
+			// The deletion that used to read as "expects 0", matching any
+			// baseline that expects success.
+			"candidate lost the success contract",
+			commandReport(t, "inv-A", &zero, "loader-v1"),
+			commandReport(t, "inv-A", nil, "loader-v2"),
+			false,
+		},
+		{
+			"neither records a success contract",
+			commandReport(t, "inv-A", nil, "loader-v1"),
+			commandReport(t, "inv-A", nil, "loader-v2"),
+			true,
+		},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d, exit, err := compareFiles(t, tc.base, tc.cand)
+			if err != nil {
+				t.Fatalf("unexpected refusal: %v", err)
+			}
+			cell := onlyCell(t, d)
+			if tc.wantGreen {
+				if cell.Classification != UnchangedCompatible || exit != ExitNoRegressions {
+					t.Fatalf("want a clean comparison, got %s/exit %d (%s)", cell.Classification, exit, cell.Reason)
+				}
+				return
+			}
+			if cell.Classification != Inconclusive || exit != ExitInconclusive {
+				t.Fatalf("want %s/exit %d, got %s/exit %d (%s)",
+					Inconclusive, ExitInconclusive, cell.Classification, exit, cell.Reason)
+			}
+			if len(d.Notes) == 0 {
+				t.Fatal("a contract change must be stated in the evidence, not only in a cell")
+			}
+		})
+	}
+}
+
+// Pre-Gate-1 evidence must stay readable: it lacks profile metadata, attach
+// mode and environment alike, and none of the new one-sided rules may turn that
+// into a parser error.
+func TestOlderEvidenceRemainsReadableAndInconclusive(t *testing.T) {
+	old := schema.ReportV01{
+		SchemaVersion: "v0.1",
+		Run:           schema.RunInfo{ID: fmt.Sprintf("legacy-%d", runIDs.Add(1))},
+		Targets:       []schema.Target{{ProfileID: "k", Required: true, Status: "pass"}},
+		Summary:       schema.SummaryInfo{Status: "pass"},
+	}
+	base, _ := greenPair(t)
+	d, exit, err := compareFiles(t, jsonOf(t, old), base)
+	if err != nil {
+		t.Fatalf("an older report must remain readable, not a hard error: %v", err)
+	}
+	if got := onlyCell(t, d).Classification; got != Inconclusive {
+		t.Fatalf("want %s, got %s", Inconclusive, got)
+	}
+	if exit != ExitInconclusive {
+		t.Fatalf("want exit %d, got %d", ExitInconclusive, exit)
+	}
+}

--- a/internal/regressiondiff/trust_test.go
+++ b/internal/regressiondiff/trust_test.go
@@ -492,16 +492,41 @@ func TestSameProfileIDWithADifferentObligationIsInconclusive(t *testing.T) {
 		})
 	}
 
-	// The control: an identical obligation still compares, and a profile block
-	// present on only one side is absence rather than change.
+	// The control: an identical obligation still compares.
 	d := build(t, report(baselineTarget), report(baselineTarget))
 	if got := onlyCell(t, d).Classification; got != UnchangedCompatible {
 		t.Fatalf("an unchanged obligation must still compare: got %s", got)
 	}
+
+	// One-sided absence is not "unknown, so carry on". Gate 2 treated it that
+	// way, which made deleting the candidate's profile block a way to turn a
+	// changed architecture back into an unchanged one -- weakening the evidence
+	// bought a greener answer. Both directions are now inconclusive.
 	half := target("k", C, true)
-	d = build(t, report(baselineTarget), report(half))
+	for _, tc := range []struct {
+		name       string
+		base, cand schema.Target
+	}{
+		{"candidate lost its profile block", baselineTarget, half},
+		{"baseline never had one", half, baselineTarget},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			d := build(t, report(tc.base), report(tc.cand))
+			cell := onlyCell(t, d)
+			if cell.Classification != Inconclusive {
+				t.Fatalf("want %s, got %s (%s)", Inconclusive, cell.Classification, cell.Reason)
+			}
+			if !strings.Contains(cell.Reason, "one side does not say") {
+				t.Fatalf("the reason must name the missing side: %q", cell.Reason)
+			}
+		})
+	}
+
+	// Both sides silent is the shape of older evidence and stays governed by
+	// the other rules rather than being refused for its age.
+	d = build(t, report(half), report(half))
 	if got := onlyCell(t, d).Classification; got != UnchangedCompatible {
-		t.Fatalf("an absent profile block is unknown, not a changed obligation: got %s", got)
+		t.Fatalf("evidence that predates profile metadata must remain comparable: got %s", got)
 	}
 }
 

--- a/internal/runner/environment.go
+++ b/internal/runner/environment.go
@@ -1,24 +1,11 @@
 package runner
 
 import (
-	"regexp"
 	"strings"
 
 	"github.com/kernel-guard/bpfcompat/internal/vm"
 	"github.com/kernel-guard/bpfcompat/pkg/schema"
 )
-
-var kernelSeriesRe = regexp.MustCompile(`^(\d+)\.(\d+)`)
-
-// kernelSeries extracts the MAJOR.MINOR series from a kernel family
-// ("5.15", "6.1.155") or an observed release ("5.15.0-152-generic").
-func kernelSeries(s string) (string, bool) {
-	m := kernelSeriesRe.FindStringSubmatch(strings.TrimSpace(s))
-	if m == nil {
-		return "", false
-	}
-	return m[1] + "." + m[2], true
-}
 
 // environmentEvidence records which environment actually ran, next to the one
 // the profile asked for.
@@ -39,10 +26,10 @@ func environmentEvidence(profile vm.Profile, observedKernel string) *schema.Envi
 		ImageSourceURL:        strings.TrimSpace(profile.Image.SourceURL),
 		ImageSHA256:           strings.TrimSpace(profile.Image.SHA256),
 	}
-	want, wantOK := kernelSeries(env.RequestedKernelFamily)
-	got, gotOK := kernelSeries(env.ObservedKernel)
-	if wantOK && gotOK {
-		match := want == got
+	// schema.KernelFamilyMatch is the same primitive the release differ uses to
+	// verify this field later. Recording and verifying must not be able to
+	// disagree about what a kernel family is.
+	if match, derivable := schema.KernelFamilyMatch(env.RequestedKernelFamily, env.ObservedKernel); derivable {
 		env.KernelFamilyMatch = &match
 	}
 	if env.RequestedKernelFamily == "" && env.ObservedKernel == "" &&

--- a/pkg/schema/kernel_series.go
+++ b/pkg/schema/kernel_series.go
@@ -1,0 +1,46 @@
+package schema
+
+import (
+	"regexp"
+	"strings"
+)
+
+// The kernel-series comparison is part of the compatibility contract, not an
+// implementation detail of whoever happens to be asking.
+//
+// It has two callers with opposite jobs: the runner, which records
+// environment.kernel_family_match while a target executes, and the release
+// differ, which has to decide whether to believe that recording. If each held
+// its own copy of "same kernel family", the two would drift, and the drift
+// would appear as either forged-looking honest evidence or trusted forged
+// evidence -- both worse than having no check. One definition, used by the
+// producer and by the verifier.
+var kernelSeriesRe = regexp.MustCompile(`^(\d+)\.(\d+)`)
+
+// KernelSeries extracts the MAJOR.MINOR series from a kernel family ("5.15",
+// "6.1.155") or an observed release ("5.15.0-152-generic"). The second return
+// is false when no series can be read, which is a different answer from "they
+// do not match".
+func KernelSeries(s string) (string, bool) {
+	m := kernelSeriesRe.FindStringSubmatch(strings.TrimSpace(s))
+	if m == nil {
+		return "", false
+	}
+	return m[1] + "." + m[2], true
+}
+
+// KernelFamilyMatch reports whether an observed kernel belongs to the requested
+// family, and whether the question could be answered at all.
+//
+// derivable is false when either side carries no readable series. A caller
+// recording evidence leaves the match unset in that case; a caller verifying
+// evidence refuses a recorded match, because a boolean derived from inputs that
+// cannot produce one is an assertion rather than a measurement.
+func KernelFamilyMatch(requestedFamily, observedKernel string) (match, derivable bool) {
+	want, wantOK := KernelSeries(requestedFamily)
+	got, gotOK := KernelSeries(observedKernel)
+	if !wantOK || !gotOK {
+		return false, false
+	}
+	return want == got, true
+}

--- a/pkg/schema/kernel_series.go
+++ b/pkg/schema/kernel_series.go
@@ -3,6 +3,8 @@ package schema
 import (
 	"regexp"
 	"strings"
+	"unicode"
+	"unicode/utf8"
 )
 
 // The kernel-series comparison is part of the compatibility contract, not an
@@ -21,10 +23,24 @@ var kernelSeriesRe = regexp.MustCompile(`^(\d+)\.(\d+)`)
 // "6.1.155") or an observed release ("5.15.0-152-generic"). The second return
 // is false when no series can be read, which is a different answer from "they
 // do not match".
+//
+// The series must end where a version stops: at the end of the string or at a
+// separator. Matching a bare prefix would read "5.15" out of "5.15forged" and
+// call it the same series as a real 5.15 kernel -- a string that is not a
+// version number at all answering a question about which kernel ran. Every
+// kernel family and observed release this project has recorded (46 distinct
+// releases across the committed evidence, 22 profile families) is followed by
+// "." or ends there, so nothing real is excluded.
 func KernelSeries(s string) (string, bool) {
-	m := kernelSeriesRe.FindStringSubmatch(strings.TrimSpace(s))
+	s = strings.TrimSpace(s)
+	m := kernelSeriesRe.FindStringSubmatch(s)
 	if m == nil {
 		return "", false
+	}
+	if rest := s[len(m[0]):]; rest != "" {
+		if r, _ := utf8.DecodeRuneInString(rest); unicode.IsLetter(r) || unicode.IsDigit(r) {
+			return "", false
+		}
 	}
 	return m[1] + "." + m[2], true
 }

--- a/pkg/schema/kernel_series_test.go
+++ b/pkg/schema/kernel_series_test.go
@@ -52,3 +52,52 @@ func TestKernelFamilyMatch(t *testing.T) {
 		}
 	}
 }
+
+// A series has to end where a version stops. "5.15forged" is not a 5.15 kernel,
+// and reading one out of it would let a string that is not a version number
+// answer a question about which kernel ran.
+func TestKernelSeriesRejectsNonDelimitedPrefixes(t *testing.T) {
+	for _, in := range []string{
+		"5.15forged", "5.15x", "4.18abc", "6.1rc1", "5.15٤",
+	} {
+		if got, ok := KernelSeries(in); ok {
+			t.Errorf("KernelSeries(%q) = %q, true; want a refusal", in, got)
+		}
+	}
+	// The separators real kernel strings actually use still read.
+	for _, tc := range []struct{ in, want string }{
+		{"5.15", "5.15"},
+		{"5.15.0-186-generic", "5.15"},
+		{"6.1-rc1", "6.1"},
+		{"5.15 ", "5.15"},
+		{"5.15_custom", "5.15"},
+	} {
+		got, ok := KernelSeries(tc.in)
+		if !ok || got != tc.want {
+			t.Errorf("KernelSeries(%q) = %q,%v; want %q,true", tc.in, got, ok, tc.want)
+		}
+	}
+	// A forged observed kernel can no longer borrow a real family's series.
+	if match, derivable := KernelFamilyMatch("5.15", "5.15forged"); derivable || match {
+		t.Errorf("KernelFamilyMatch(5.15, 5.15forged) = %v,%v; want false,false", match, derivable)
+	}
+}
+
+// Every kernel family and observed release this project has recorded must still
+// parse. The rule is only safe because nothing real is shaped like the strings
+// it now refuses.
+func TestKernelSeriesAcceptsEveryRealRecordedKernel(t *testing.T) {
+	for _, in := range []string{
+		// Profile families.
+		"4.4", "4.14", "4.15", "4.18", "5.4", "5.6", "5.8", "5.10", "5.14", "5.15",
+		"6.1", "6.1.155", "6.4", "6.5", "6.6", "6.8", "6.11", "6.12", "6.14", "6.17", "6.19", "7.0",
+		// Observed releases.
+		"4.14.26-54.32.amzn2.x86_64", "4.15.0-212-generic", "4.18.0-553.124.4.el8_10.x86_64",
+		"4.4.0-210-generic", "5.10.0-42-cloud-amd64", "5.15.0-186-generic",
+		"5.14.0-687.36.1.el9_8.x86_64", "6.12.0-107.el9uek.x86_64",
+	} {
+		if _, ok := KernelSeries(in); !ok {
+			t.Errorf("KernelSeries(%q) refused a real recorded kernel string", in)
+		}
+	}
+}

--- a/pkg/schema/kernel_series_test.go
+++ b/pkg/schema/kernel_series_test.go
@@ -1,0 +1,54 @@
+package schema
+
+import "testing"
+
+// Real strings from committed evidence and profile definitions. The producer
+// and the release differ both depend on these answers, so they are pinned.
+func TestKernelSeries(t *testing.T) {
+	for _, tc := range []struct {
+		in     string
+		want   string
+		wantOK bool
+	}{
+		{"5.15", "5.15", true},
+		{"6.1.155", "6.1", true},
+		{"5.15.0-152-generic", "5.15", true},
+		{"5.14.0-687.36.1.el9_8.x86_64", "5.14", true},
+		{"6.12.0-107.el9uek.x86_64", "6.12", true},
+		{"4.14.336-257.562.amzn2.x86_64", "4.14", true},
+		{"  5.10.0-28-amd64  ", "5.10", true},
+		{"", "", false},
+		{"unknown", "", false},
+		{"rhel-latest", "", false},
+		{"v5.15", "", false},
+	} {
+		got, ok := KernelSeries(tc.in)
+		if got != tc.want || ok != tc.wantOK {
+			t.Errorf("KernelSeries(%q) = %q,%v; want %q,%v", tc.in, got, ok, tc.want, tc.wantOK)
+		}
+	}
+}
+
+func TestKernelFamilyMatch(t *testing.T) {
+	for _, tc := range []struct {
+		requested, observed string
+		match, derivable    bool
+	}{
+		{"5.15", "5.15.0-186-generic", true, true},
+		{"5.14", "5.14.0-687.36.1.el9_8.x86_64", true, true},
+		{"4.18", "5.15.0-206.el8uek", false, true},
+		{"5.15", "6.12.0-107.el9uek.x86_64", false, true},
+		// Not derivable is a third answer, distinct from "they do not match":
+		// the producer leaves the field unset, and the verifier refuses a
+		// report that filled it in anyway.
+		{"", "5.15.0-1", false, false},
+		{"5.15", "", false, false},
+		{"rhel-latest", "unknown", false, false},
+	} {
+		match, derivable := KernelFamilyMatch(tc.requested, tc.observed)
+		if match != tc.match || derivable != tc.derivable {
+			t.Errorf("KernelFamilyMatch(%q, %q) = %v,%v; want %v,%v",
+				tc.requested, tc.observed, match, derivable, tc.match, tc.derivable)
+		}
+	}
+}


### PR DESCRIPTION
## Why

`bpfcompat diff` is intended to block releases. Evidence that is ambiguous,
contradictory, or missing the fields that prove two runs were about the same
thing must fail closed — never produce `exit 0`.

Each finding below was reproduced against merged `main` (46f4da7) first. All four
produced `NO_NEW_REGRESSIONS` / exit 0 before the fix.

## Findings

**1. JSON semantic alias collision.** The duplicate-key rule compared exact
spellings, but `encoding/json` falls back to case-insensitive field matching:
`"verdict"` and `"Verdict"` in one object both bind to `Verdict`, and the later
wins. A report reading `INCOMPATIBLE`/`fail` on every visible line decoded to
`COMPATIBLE`/`pass` and compared green. Keys are now compared case-folded —
exactly where the decoder draws the line. Measured against the real schema
types, `profileid` and `ProfileID` do *not* bind, so no underscore or
field-name transformation is invented, and unrelated extension fields are
unaffected.

**2. Unverifiable `kernel_family_match`.** Checking only that the inputs exist
proved the boolean had something to be derived from, not that it was:
`requested 4.18, observed 5.15.0-206.el8uek, match true` let the differ treat a
kernel series nothing tested as established — the environment-identity failure
Gate 1 exists to prevent, reintroduced through a field nobody verified. The
runner's kernel-series comparison moves to `schema.KernelFamilyMatch`; the
producer and the verifier now share one primitive, so they cannot drift into
refusing honest evidence. A match whose inputs carry no readable series is also
refused — the producer would have left it unset.

**3. One-sided loss of obligation identity.** Architecture, distro, version and
profile kernel family were compared only when both sides spoke, so deleting the
candidate's profile block turned a *changed* architecture back into an unchanged
one. Absence on one side now means equivalence cannot be established. Absence on
both stays comparable: that is the shape of older evidence, and age is not
tampering.

**4. One-sided loss of test-contract identity.** The same rule for
`validation.attach_mode` and for command mode's `invocation_sha256`. 
`expected_exit_code` is a plain `int`, so a deleted field decoded as `0` and
matched any baseline expecting success; its presence is now carried from the raw
JSON alongside `required`.

## Tests

- Decoder alias behaviour pinned by test, so the rule follows measurement rather
  than assumption (including the negative cases).
- `kernel_family_match`: correct true/false accepted, forged true/false and
  underivable refused, absent stays unknown; a producer round-trip test fails
  first if the two sides of the primitive ever drift.
- One-sided presence tables for all four obligation dimensions, attach mode and
  the command contract.
- Property test: 140 deletion/alias/flip mutations across five scenarios,
  asserting weakened evidence never turns a non-green comparison green.
- Fuzz seeds for all four classes; local campaigns of 2.81M and 2.74M executions
  passed. CI runs the committed seed corpus only, so it stays deterministic.

## Compatibility

All 59 readable committed reports still load. None carries
`kernel_family_match`, and live reports agree with the verifier by construction.
Older evidence remains readable and inconclusive rather than becoming a parser
error.

## Non-goals

No persistence, SaaS, history or API. No new classification states, no schema
bump, no change to the exit-code contract. Not Gate 3.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Release comparisons now conservatively mark one-sided or missing evidence as inconclusive instead of treating it as unchanged.
  * Kernel-family claims are verified against recorded environment details.
  * Conflicting or case-ambiguous JSON fields are rejected.
  * Missing command exit-code and identity metadata is detected reliably.

* **Consistency**
  * Kernel-series matching is now applied consistently when recording and evaluating evidence.

* **Tests**
  * Expanded coverage for legacy reports, malformed evidence, metadata removal, aliases, and forged environment claims.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->